### PR TITLE
feat: add molecules breadcrumb & storybook (#21)

### DIFF
--- a/src/components/molecules/Breadcrumb/Breadcrumb.stories.tsx
+++ b/src/components/molecules/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import Breadcrumb from './Breadcrumb';
+
+const meta = {
+  title: 'Molecules/Breadcrumb',
+  component: Breadcrumb,
+  tags: ['autodocs'],
+  argTypes: {
+    items: {
+      control: 'object',
+      description: '카테고리 계층 아이템 배열',
+    },
+    className: {
+      control: 'text',
+      description: '추가 CSS 클래스',
+    },
+  },
+} satisfies Meta<typeof Breadcrumb>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 대분류만
+export const MainCategoryOnly: Story = {
+  args: {
+    items: [{ label: '스낵' }],
+  },
+};
+
+// 대분류 > 중분류
+export const WithSubCategory: Story = {
+  args: {
+    items: [{ label: '스낵', href: '/products?category=1' }, { label: '과자' }],
+  },
+};
+
+// 음료 > 청량/탄산음료
+export const Beverage: Story = {
+  args: {
+    items: [{ label: '음료', href: '/products?category=2' }, { label: '청량 ∙ 탄산 음료' }],
+  },
+};
+
+// 간편식 > 컵라면
+export const SimpleFood: Story = {
+  args: {
+    items: [{ label: '간편식', href: '/products?category=4' }, { label: '컵라면' }],
+  },
+};
+
+// 신선식품 > 샐러드
+export const FreshFood: Story = {
+  args: {
+    items: [{ label: '신선식품', href: '/products?category=5' }, { label: '샐러드' }],
+  },
+};
+
+// 원두커피 > 드립커피
+export const Coffee: Story = {
+  args: {
+    items: [{ label: '원두커피', href: '/products?category=6' }, { label: '드립커피' }],
+  },
+};
+
+// 비품 > 일회용품(친환경)
+export const Supplies: Story = {
+  args: {
+    items: [{ label: '비품', href: '/products?category=7' }, { label: '일회용품 (친환경)' }],
+  },
+};

--- a/src/components/molecules/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/molecules/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { clsx } from '@/utils/clsx';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+export interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+const Breadcrumb = ({ items, className }: BreadcrumbProps) => (
+  <nav aria-label="Breadcrumb" className={clsx('flex items-center', className)}>
+    <ol className="flex items-center gap-8">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+
+        return (
+          <li key={item.href || item.label} className="flex items-center gap-8">
+            {item.href && !isLast ? (
+              <Link
+                href={item.href}
+                className={clsx(
+                  'text-14 font-normal',
+                  'text-gray-400 hover:text-gray-600',
+                  'transition-colors'
+                )}
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span
+                className={clsx('text-14 font-normal', isLast ? 'text-gray-900' : 'text-gray-200')}
+                aria-current={isLast ? 'page' : undefined}
+              >
+                {item.label}
+              </span>
+            )}
+
+            {!isLast && (
+              <svg
+                width="8"
+                height="9"
+                viewBox="0 0 8 14"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden="true"
+                className="text-gray-200"
+              >
+                <path
+                  d="M1.06055 0L7.95508 6.89355L1.06055 13.7881L0 12.7275L5.83301 6.89453L0 1.06055L1.06055 0Z"
+                  fill="currentColor"
+                />
+              </svg>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  </nav>
+);
+
+export default Breadcrumb;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,19 @@
+// 경로 상수
+export const PATHNAME = {
+  HOME: '/',
+  PRODUCTS: '/products',
+  PRODUCT_DETAIL: (id: string) => `/products/${id}`,
+  PURCHASE_REQUESTS: '/purchase-requests',
+  PURCHASE_REQUEST_DETAIL: (id: string) => `/purchase-requests/${id}`,
+  CART: '/cart',
+  MYPAGE: '/mypage',
+} as const;
+
+// 자주 사용되는 breadcrumb 아이템
+export const BREADCRUMB_ITEMS = {
+  HOME: { label: '홈', href: PATHNAME.HOME },
+  PRODUCTS: { label: '상품', href: PATHNAME.PRODUCTS },
+  PURCHASE_REQUESTS: { label: '구매 요청', href: PATHNAME.PURCHASE_REQUESTS },
+  CART: { label: '장바구니', href: PATHNAME.CART },
+  MYPAGE: { label: '마이페이지', href: PATHNAME.MYPAGE },
+} as const;

--- a/src/domains/category/index.ts
+++ b/src/domains/category/index.ts
@@ -1,0 +1,143 @@
+// src/domains/category/index.ts
+
+// 대분류
+export const PARENT_CATEGORIES = [
+  { id: 1, key: 'snack', name: '스낵' },
+  { id: 2, key: 'drink', name: '음료' },
+  { id: 3, key: 'water', name: '생수' },
+  { id: 4, key: 'simple-meal', name: '간편식' },
+  { id: 5, key: 'fresh-food', name: '신선식' },
+  { id: 6, key: 'coffee-beans', name: '원두커피' },
+  { id: 7, key: 'supplies', name: '비품' },
+] as const;
+
+// 소분류
+export const CHILD_CATEGORIES = [
+  // 스낵(1)
+  { id: 101, parentId: 1, key: 'snack-snack', name: '과자' },
+  { id: 102, parentId: 1, key: 'snack-cookie', name: '쿠키' },
+  { id: 103, parentId: 1, key: 'snack-biscuit', name: '비스켓류' },
+  { id: 104, parentId: 1, key: 'snack-chocolate', name: '초콜릿류' },
+  { id: 105, parentId: 1, key: 'snack-candy', name: '캔디류' },
+  { id: 106, parentId: 1, key: 'snack-jelly', name: '젤리류' },
+  { id: 107, parentId: 1, key: 'snack-cereal-bar', name: '시리얼바' },
+  { id: 108, parentId: 1, key: 'snack-nuts', name: '견과류' },
+
+  // 음료(2)
+  { id: 201, parentId: 2, key: 'drink-soda', name: '탄산음료' },
+  { id: 202, parentId: 2, key: 'drink-fruit', name: '과즙음료' },
+  { id: 203, parentId: 2, key: 'drink-energy', name: '에너지음료' },
+  { id: 204, parentId: 2, key: 'drink-ion', name: '이온음료' },
+  { id: 205, parentId: 2, key: 'drink-health', name: '건강음료' },
+  { id: 206, parentId: 2, key: 'drink-tea', name: '차류' },
+
+  // 생수(3)
+  { id: 301, parentId: 3, key: 'water-water', name: '생수' },
+  { id: 302, parentId: 3, key: 'water-sparkling', name: '스파클링' },
+
+  // 간편식(4)
+  { id: 401, parentId: 4, key: 'simple-cup-ramen', name: '컵라면' },
+  { id: 402, parentId: 4, key: 'simple-sausage', name: '소시지' },
+  { id: 403, parentId: 4, key: 'simple-egg', name: '계란' },
+  { id: 404, parentId: 4, key: 'simple-cup-rice', name: '컵밥류' },
+  { id: 405, parentId: 4, key: 'simple-cereal', name: '시리얼' },
+
+  // 신선식(5)
+  { id: 501, parentId: 5, key: 'fresh-fruit', name: '과일' },
+  { id: 502, parentId: 5, key: 'fresh-salad', name: '샐러드' },
+  { id: 503, parentId: 5, key: 'fresh-bread', name: '빵' },
+  { id: 504, parentId: 5, key: 'fresh-sandwich', name: '샌드위치' },
+  { id: 505, parentId: 5, key: 'fresh-yogurt', name: '요거트류' },
+  { id: 506, parentId: 5, key: 'fresh-dairy', name: '유제품' },
+
+  // 원두커피(6)
+  { id: 601, parentId: 6, key: 'coffee-drip', name: '드립커피' },
+  { id: 602, parentId: 6, key: 'coffee-beans', name: '원두' },
+  { id: 603, parentId: 6, key: 'coffee-capsule', name: '캡슐커피' },
+
+  // 비품(7)
+  { id: 701, parentId: 7, key: 'supplies-disposable', name: '일회용품' },
+  { id: 702, parentId: 7, key: 'supplies-office', name: '사무용품' },
+  { id: 703, parentId: 7, key: 'supplies-cleaning', name: '청소용품' },
+  { id: 704, parentId: 7, key: 'supplies-hygiene', name: '위생용품' },
+] as const;
+
+export type ParentCategory = (typeof PARENT_CATEGORIES)[number];
+export type ChildCategory = (typeof CHILD_CATEGORIES)[number];
+
+export type ParentCategoryId = ParentCategory['id'];
+export type ChildCategoryId = ChildCategory['id'];
+
+export type ParentCategoryKey = ParentCategory['key'];
+export type ChildCategoryKey = ChildCategory['key'];
+
+const parentById = new Map<ParentCategoryId, ParentCategory>(
+  PARENT_CATEGORIES.map((c) => [c.id, c])
+);
+
+const parentByKey = new Map<ParentCategoryKey, ParentCategory>(
+  PARENT_CATEGORIES.map((c) => [c.key, c])
+);
+
+const childById = new Map<ChildCategoryId, ChildCategory>(CHILD_CATEGORIES.map((c) => [c.id, c]));
+
+const childrenByParentId = new Map<ParentCategoryId, ChildCategory[]>(
+  CHILD_CATEGORIES.reduce<Map<ParentCategoryId, ChildCategory[]>>((map, child) => {
+    const list = map.get(child.parentId) ?? [];
+    map.set(child.parentId, [...list, child]);
+    return map;
+  }, new Map<ParentCategoryId, ChildCategory[]>())
+);
+
+export function getParentById(id: number | null | undefined) {
+  if (id == null) return null;
+  return parentById.get(id as ParentCategoryId) ?? null;
+}
+
+export function getParentByKey(key: ParentCategoryKey) {
+  return parentByKey.get(key) ?? null;
+}
+
+export function getChildById(id: number | null | undefined) {
+  if (id == null) return null;
+  return childById.get(id as ChildCategoryId) ?? null;
+}
+
+export function getChildrenByParentId(parentId: number | null | undefined) {
+  if (parentId == null) return [];
+  return childrenByParentId.get(parentId as ParentCategoryId) ?? [];
+}
+
+export type CategoryBreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+export function buildParentPath(parent: ParentCategory) {
+  return `/products/${parent.key}`;
+}
+
+export function buildChildPath(parent: ParentCategory, child: ChildCategory) {
+  return `/products/${parent.key}/${child.key}`;
+}
+
+export function buildProductBreadcrumb(params: {
+  categoryId?: number | null;
+}): CategoryBreadcrumbItem[] {
+  const { categoryId } = params;
+
+  const items: CategoryBreadcrumbItem[] = [];
+
+  const child = getChildById(categoryId ?? null);
+
+  if (child) {
+    const parent = getParentById(child.parentId);
+
+    if (parent) {
+      items.push({ label: parent.name, href: buildParentPath(parent) });
+      items.push({ label: child.name, href: buildChildPath(parent, child) });
+    }
+  }
+
+  return items;
+}

--- a/src/utils/breadcrumb.ts
+++ b/src/utils/breadcrumb.ts
@@ -1,0 +1,35 @@
+import { type BreadcrumbItem } from '@/components/molecules/Breadcrumb/Breadcrumb';
+// eslint-disable-next-line import/no-unresolved
+import { BREADCRUMB_ITEMS } from '@/constants';
+
+export function generateHomeBreadcrumb(): BreadcrumbItem[] {
+  return [BREADCRUMB_ITEMS.HOME];
+}
+
+export function generateProductsBreadcrumb(): BreadcrumbItem[] {
+  return [BREADCRUMB_ITEMS.HOME, BREADCRUMB_ITEMS.PRODUCTS];
+}
+
+export function generateCartBreadcrumb(): BreadcrumbItem[] {
+  return [BREADCRUMB_ITEMS.HOME, BREADCRUMB_ITEMS.CART];
+}
+
+export function generatePurchaseRequestsBreadcrumb(): BreadcrumbItem[] {
+  return [BREADCRUMB_ITEMS.HOME, BREADCRUMB_ITEMS.PURCHASE_REQUESTS];
+}
+
+export function generatePurchaseRequestDetailBreadcrumb(requestId: string): BreadcrumbItem[] {
+  return [
+    BREADCRUMB_ITEMS.HOME,
+    BREADCRUMB_ITEMS.PURCHASE_REQUESTS,
+    { label: `Request #${requestId.slice(0, 8)}` },
+  ];
+}
+
+export function generateMyPageBreadcrumb(username?: string): BreadcrumbItem[] {
+  const items: BreadcrumbItem[] = [BREADCRUMB_ITEMS.HOME, BREADCRUMB_ITEMS.MYPAGE];
+  if (username) {
+    items.push({ label: username });
+  }
+  return items;
+}


### PR DESCRIPTION
## 📝 변경사항
- Molecules 레벨 Breadcrumb 컴포넌트 구현
- 공통 페이지용 Breadcrumb 유틸 함수 추가
- Breadcrumb Storybook 스토리 작성

## 🔨 작업 내용
- [x] `Breadcrumb` Molecule 컴포넌트 구현 (`components/molecules/Breadcrumb/Breadcrumb.tsx`)
  - `items`, `separator`, `className` 등 props 정의
  - 마지막 항목에 `aria-current="page"` 적용
  - `nav` + `aria-label="Breadcrumb"`로 접근성 대응
- [x] 공통 Breadcrumb 유틸 함수 추가 (`domain/category/index.ts`)
  - `buildCategoryBreadcrumbFromIds` 함수 구현  
    (parentCategoryId + categoryId 기반 breadcrumb 생성)
  - parent/child 카테고리 lookup helper 구성
  - slug 기반 URL 생성 로직 포함
- [x] Storybook 스토리 작성
  - 기본 Breadcrumb 스토리
  - 다양한 케이스(길어진 경로, 현재 페이지 강조 등) 추가

## 🧪 테스트 방법
1. `npm run dev` 실행 후 Breadcrumb가 포함된 페이지 접속
2. CategoryId가 있는 페이지에서 올바른 label / href 구조로 Breadcrumb 표시되는지 확인
3. 키보드(Tab) 포커스 이동 테스트:
   - 링크 focus-visible 스타일 정상 표시 확인
   - 마지막 항목에 `aria-current="page"` 적용 여부 확인
4. `npm run storybook` 실행 후 Storybook에서 다양한 Breadcrumb 스토리 동작 확인

## 📸 스크린샷 (UI 변경 시)
<img width="303" height="156" alt="Screenshot 2025-12-01 at 6 37 07 PM" src="https://github.com/user-attachments/assets/e2da58ae-299c-469c-94d0-e03ad67098d4" />
<img width="276" height="164" alt="Screenshot 2025-12-01 at 6 37 26 PM" src="https://github.com/user-attachments/assets/5ab9053f-247a-44ea-aed2-c80f01d547ef" />


## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #21 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 브레드크럼 네비게이션 컴포넌트 추가
  * 홈, 상품, 장바구니, 구매요청, 마이페이지 등 주요 페이지에서 현재 위치를 표시하는 브레드크럼 경로 지원
  * 상품 카테고리 기반 동적 브레드크럼 생성 기능

* **Documentation**
  * Storybook에 브레드크럼 컴포넌트 스토리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->