### PR TITLE
feat: add GNB components and navigation constants (#39)

### DIFF
--- a/src/components/molecules/GNBBrand/GNBBrand.stories.tsx
+++ b/src/components/molecules/GNBBrand/GNBBrand.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import GNBBrand from './GNBBrand';
+
+const meta = {
+  title: 'Molecules/GNBBrand',
+  component: GNBBrand,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'GNB(Global Navigation Bar)의 브랜드 영역을 담당하는 컴포넌트입니다.\n- 로고를 렌더링하고, 클릭 시 홈(루트 경로)로 이동합니다.\n- 상단 GNB의 좌측 영역에 배치됩니다.',
+      },
+    },
+  },
+} satisfies Meta<typeof GNBBrand>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '가장 기본 형태의 브랜드 컴포넌트입니다. 기본 로고만 표시하며, 클릭하면 홈으로 이동합니다.',
+      },
+    },
+  },
+};

--- a/src/components/molecules/GNBBrand/GNBBrand.tsx
+++ b/src/components/molecules/GNBBrand/GNBBrand.tsx
@@ -1,0 +1,11 @@
+import Link from 'next/link';
+import Logo from '@/components/atoms/Logo/Logo';
+import { PATHNAME } from '@/constants';
+
+const GNBBrand = () => (
+  <Link href={PATHNAME.HOME} className="flex items-center">
+    <Logo size="sm" />
+  </Link>
+);
+
+export default GNBBrand;

--- a/src/components/molecules/GNBPrimaryNav/GNBPrimaryNav.stories.tsx
+++ b/src/components/molecules/GNBPrimaryNav/GNBPrimaryNav.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import GNBPrimaryNav from './GNBPrimaryNav';
+
+const meta = {
+  title: 'Molecules/GNBPrimaryNav',
+  component: GNBPrimaryNav,
+  tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/products',
+      },
+    },
+    docs: {
+      description: {
+        component:
+          'GNB(Global Navigation Bar) 상단의 텍스트 네비게이션 바입니다. 역할(user, manager, admin)에 따라 보여지는 메뉴가 달라지며, 현재 경로가 일치하는 메뉴는 강조 스타일이 적용됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    role: {
+      control: 'select',
+      options: ['user', 'manager', 'admin'],
+      description: '사용자 역할',
+    },
+    activePath: {
+      control: 'text',
+      description: '현재 활성화된 경로 (선택사항)',
+    },
+    onItemClick: {
+      action: 'item-clicked',
+      description: '네비게이션 메뉴 아이템 클릭 시 호출되는 콜백',
+    },
+    onMenuClick: {
+      action: 'menu-clicked',
+      description: '햄버거 메뉴 버튼 클릭 시 호출되는 콜백 (모바일/태블릿)',
+    },
+    isMenuOpen: {
+      control: 'boolean',
+      description: '햄버거 메뉴가 열려있는지 여부',
+    },
+    menuControlsId: {
+      control: 'text',
+      description: '햄버거 메뉴가 제어하는 요소의 ID',
+    },
+    menuButtonClassName: {
+      control: 'text',
+      description: '모바일 햄버거 버튼에 적용할 추가 CSS 클래스',
+    },
+    navClassName: {
+      control: 'text',
+      description: '데스크탑 네비게이션 메뉴에 적용할 추가 CSS 클래스',
+    },
+  },
+} satisfies Meta<typeof GNBPrimaryNav>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 1) User 역할
+export const UserRole: Story = {
+  args: {
+    role: 'user',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '일반 사용자(user) 역할의 메뉴입니다. 상품 리스트와 구매 요청 내역만 표시됩니다.',
+      },
+    },
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+};
+
+// 2) Manager 역할
+export const ManagerRole: Story = {
+  args: {
+    role: 'manager',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '매니저(manager) 역할의 메뉴입니다. 상품 등록 내역, 구매 요청 관리, 구매 내역 확인이 추가로 표시됩니다.',
+      },
+    },
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+};
+
+// 3) Admin 역할
+export const AdminRole: Story = {
+  args: {
+    role: 'admin',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '관리자(admin) 역할의 메뉴입니다. 모든 메뉴가 표시되며 관리 메뉴가 추가됩니다.',
+      },
+    },
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+  },
+};

--- a/src/components/molecules/GNBPrimaryNav/GNBPrimaryNav.tsx
+++ b/src/components/molecules/GNBPrimaryNav/GNBPrimaryNav.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+import { clsx } from '@/utils/clsx';
+import { IconButton } from '@/components/atoms/IconButton/IconButton';
+import { type UserRole, type AppRouteKey, getGNBPrimaryNavConfig, isNavActive } from '@/constants';
+
+/**
+ * GNB 상단의 텍스트 네비게이션 바
+ * - role(user | manager | admin)에 따라 GNB 메뉴가 달라진다.
+ * - 현재 경로(activePath 또는 pathname)를 기반으로 활성 상태를 판단한다.
+ */
+export interface GNBPrimaryNavProps {
+  role: UserRole;
+  activePath?: string;
+  onItemClick?: (key: AppRouteKey) => void;
+  onMenuClick?: () => void;
+
+  /** 모바일 햄버거 버튼 className */
+  menuButtonClassName?: string;
+
+  /** 데스크탑 네비게이션 메뉴 className */
+  navClassName?: string;
+
+  /** 햄버거 메뉴 열림 여부 (컨트롤 모드) */
+  isMenuOpen?: boolean;
+
+  /** 햄버거 메뉴가 제어하는 요소의 ID (a11y 용) */
+  menuControlsId?: string;
+}
+
+const GNBPrimaryNav: React.FC<GNBPrimaryNavProps> = ({
+  role,
+  activePath,
+  onItemClick,
+  onMenuClick,
+  menuButtonClassName,
+  navClassName,
+  isMenuOpen,
+  menuControlsId,
+}) => {
+  const pathname = usePathname();
+  const currentPath = activePath ?? pathname ?? '';
+
+  const items = getGNBPrimaryNavConfig(role);
+
+  return (
+    <>
+      {/* 모바일: 햄버거 메뉴 */}
+      <IconButton
+        variant="default"
+        size="md"
+        onClick={onMenuClick}
+        aria-label={isMenuOpen ? '메인 메뉴 닫기' : '메인 메뉴 열기'}
+        aria-expanded={isMenuOpen ?? false}
+        aria-controls={menuControlsId}
+        className={clsx('desktop:hidden', menuButtonClassName)}
+      >
+        <Image src="/icons/hamburger.svg" alt="메인 메뉴" width={24} height={24} />
+      </IconButton>
+
+      {/* 데스크탑: 네비게이션 */}
+      <nav
+        aria-label="주요 페이지"
+        className={clsx('hidden desktop:flex items-center gap-32', navClassName)}
+      >
+        {items.map((item) => {
+          const active = isNavActive(currentPath, item.href);
+
+          return (
+            <Link
+              key={item.key}
+              href={item.href}
+              onClick={() => onItemClick?.(item.key)}
+              aria-current={active ? 'page' : undefined}
+              className={clsx(
+                'text-14 leading-22 transition-colors',
+                active ? 'font-semibold text-black' : 'text-gray-500 hover:text-black'
+              )}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+};
+
+export default GNBPrimaryNav;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,4 +1,4 @@
-// 경로 상수
+// 경로(Path) 상수
 export const PATHNAME = {
   HOME: '/',
   PRODUCTS: '/products',
@@ -9,7 +9,7 @@ export const PATHNAME = {
   MYPAGE: '/mypage',
 } as const;
 
-// 자주 사용되는 breadcrumb 아이템
+// 공통 Breadcrumb 아이템
 export const BREADCRUMB_ITEMS = {
   HOME: { label: '홈', href: PATHNAME.HOME },
   PRODUCTS: { label: '상품', href: PATHNAME.PRODUCTS },
@@ -17,3 +17,13 @@ export const BREADCRUMB_ITEMS = {
   CART: { label: '장바구니', href: PATHNAME.CART },
   MYPAGE: { label: '마이페이지', href: PATHNAME.MYPAGE },
 } as const;
+
+// API 서버 기본 URL
+export const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL!;
+export const API_VERSION = 'v1';
+export const API = `${BASE_URL}/api/${API_VERSION}`;
+
+export type { UserRole } from './roles';
+export type { AppRouteKey } from './routes';
+export { ROUTES } from './routes';
+export { getGNBPrimaryNavConfig, isNavActive } from './navigation';

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,0 +1,74 @@
+import type { UserRole } from './roles';
+import { ROUTES, type AppRouteKey } from './routes';
+
+/**
+ * 역할별로 GNB에서 보여줄 메뉴 목록
+ */
+const ROLE_NAV_KEYS: Record<UserRole, AppRouteKey[]> = {
+  // 사용자: 상품 리스트 / 구매 요청 내역 / 상품 등록 내역
+  user: ['product-list', 'purchase-request-list', 'product-register-list'],
+
+  // 관리자: 유저 메뉴 + 구매 요청 관리 + 구매 내역 확인
+  manager: [
+    'product-list',
+    'purchase-request-list',
+    'product-register-list',
+    'purchase-request-manage',
+    'purchase-history-check',
+  ],
+
+  // 최고관리자: 모든 메뉴
+  admin: [
+    'product-list',
+    'purchase-request-list',
+    'product-register-list',
+    'purchase-request-manage',
+    'purchase-history-check',
+    'management',
+  ],
+};
+
+/**
+ * 역할별로 라우트 객체 배열을 만들어주는 내부 함수
+ */
+const getPrimaryNavItemsByRole = (role: UserRole) => ROLE_NAV_KEYS[role].map((key) => ROUTES[key]);
+
+/**
+ * GNB에서 사용할 메뉴 config 반환
+ */
+export const getGNBPrimaryNavConfig = (role: UserRole) =>
+  getPrimaryNavItemsByRole(role).map((route) => ({
+    key: route.key,
+    label: route.label,
+    href: route.href,
+  }));
+
+/**
+ * 현재 페이지가 특정 메뉴에 속하는지 판단하는 함수
+ *
+ * - /[companyId] 제거
+ * - 하위 경로도 active 처리
+ *
+ * 예:
+ * currentPath: /acme/products/mine
+ * targetHref:  /[companyId]/products
+ * → active = true
+ */
+export const isNavActive = (currentPath: string, targetHref: string): boolean => {
+  if (!currentPath || !targetHref) return false;
+
+  // /[companyId] 제거한 패턴
+  const normalizePattern = (href: string) => href.replace('/[companyId]', '') || '/';
+
+  // 실제 경로에서 회사 ID 제거
+  const normalizeCurrent = (path: string) => {
+    const segments = path.split('/').filter(Boolean);
+    if (segments.length <= 1) return '/';
+    return `/${segments.slice(1).join('/')}`;
+  };
+
+  const target = normalizePattern(targetHref); // ex: /products
+  const current = normalizeCurrent(currentPath); // ex: /products/mine
+
+  return current === target || current.startsWith(`${target}/`);
+};

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,0 +1,9 @@
+/** 인증된 사용자의 역할 */
+export type UserRole = 'user' | 'manager' | 'admin';
+
+// 필요하다면 역할 라벨, 설명도 같이 정의
+export const ROLE_LABEL: Record<UserRole, string> = {
+  user: '사용자',
+  manager: '관리자',
+  admin: '최고관리자',
+};

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,0 +1,46 @@
+export type AppRouteKey =
+  | 'product-list'
+  | 'purchase-request-list'
+  | 'product-register-list'
+  | 'purchase-request-manage'
+  | 'purchase-history-check'
+  | 'management';
+
+export interface AppRouteConfig {
+  key: AppRouteKey;
+  label: string;
+  href: string;
+}
+
+export const ROUTES: Record<AppRouteKey, AppRouteConfig> = {
+  'product-list': {
+    key: 'product-list',
+    label: '상품 리스트',
+    href: '/[companyId]/products',
+  },
+  'purchase-request-list': {
+    key: 'purchase-request-list',
+    label: '구매 요청 내역',
+    href: '/[companyId]/my/purchase-requests',
+  },
+  'product-register-list': {
+    key: 'product-register-list',
+    label: '상품 등록 내역',
+    href: '/[companyId]/products/mine',
+  },
+  'purchase-request-manage': {
+    key: 'purchase-request-manage',
+    label: '구매 요청 관리',
+    href: '/[companyId]/manager/requests',
+  },
+  'purchase-history-check': {
+    key: 'purchase-history-check',
+    label: '구매 내역 확인',
+    href: '/[companyId]/manager/purchase-history',
+  },
+  management: {
+    key: 'management',
+    label: '관리',
+    href: '/[companyId]/admin',
+  },
+};


### PR DESCRIPTION
## 📝 변경사항
- GNB(UI 상단 글로벌 네비게이션) 구현을 위한 핵심 컴포넌트와 네비게이션 상수를 추가했습니다.  
- 모바일/데스크탑 반응형 및 역할(role) 기반 메뉴 구성을 포함합니다.

## 🔨 작업 내용

- [x] **GNBBrand 컴포넌트 추가**
  - 서비스 로고 및 홈 이동 역할 담당

- [x] **GNBPrimaryNav 컴포넌트 추가**
  - 사용자 역할(user/manager/admin)에 따라 다른 메뉴 제공
  - 모바일 / 데스크탑 환경 모두 대응
  - 현재 경로(active path) 하이라이트 처리

- [x] **네비게이션 관련 상수 추가**
  - `roles.ts`
  - `routes.ts`
  - `navigation.ts`
  - GNB 구성을 위한 중앙 집중형 설정 파일 생성

- [x] **Storybook 스토리 추가**
  - 각 GNB 컴포넌트에 대해 모바일/데스크탑 기준 스토리 작성  
  - 역할별 메뉴 렌더링 검증 가능하도록 구성
  
## 🧪 테스트 방법
1. 역할(user/manager/admin) 변경 시 메뉴 구성이 정상적으로 반영되는지 확인  
2. 모바일/데스크탑 환경에서 네비게이션이 올바르게 표시되는지 확인  
3. 현재 경로와 일치하는 메뉴가 active 스타일로 표시되는지 검증  
4. Storybook에서 각 컴포넌트가 문제 없이 렌더링되는지 테스트  

## 📸 스크린샷 (UI 변경 시)
<img width="396" height="50" alt="Screenshot 2025-12-05 at 6 48 28 PM" src="https://github.com/user-attachments/assets/1b7d1cea-39c8-4a5e-9346-f9e0311f02e0" />
<img width="546" height="53" alt="Screenshot 2025-12-05 at 6 48 32 PM" src="https://github.com/user-attachments/assets/30c2da43-291d-4581-84cb-874688facf26" />
<img width="604" height="46" alt="Screenshot 2025-12-05 at 6 48 38 PM" src="https://github.com/user-attachments/assets/9eba9865-3b4c-41ae-873f-e13f2e245bc3" />


## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x]  문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #39 
