### PR TITLE
refactor: rename UserProfile component and add company prop (#21)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes';
+import './.next/dev/types/routes';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/molecules/UserProfile/UserProfile.stories.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.stories.tsx
@@ -18,6 +18,10 @@ const meta = {
       control: 'text',
       description: '사용자 이름',
     },
+    company: {
+      control: 'object',
+      description: '회사 정보',
+    },
     avatarSrc: {
       control: 'text',
       description: '아바타 이미지 URL',
@@ -41,6 +45,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     name: 'Name',
+    company: {
+      name: 'Company Name',
+    },
   },
   parameters: {
     docs: {
@@ -53,9 +60,12 @@ export const Default: Story = {
 };
 
 // 아바타 이미지 있음
-export const WithAvatar: Story = {
+export const WithProfileImage: Story = {
   args: {
     name: 'Name',
+    company: {
+      name: 'Company Name',
+    },
     avatarSrc: '/images/test-profile-image.jpg',
   },
   parameters: {

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -6,6 +6,9 @@ import { clsx } from '@/utils/clsx';
 
 export interface UserProfileProps {
   name: string;
+  company: {
+    name: string;
+  };
   avatarSrc?: string;
   profileHref?: string;
   className?: string;
@@ -13,6 +16,7 @@ export interface UserProfileProps {
 
 const UserProfile = ({
   name,
+  company,
   avatarSrc,
   profileHref = '/me/profile',
   className,
@@ -25,8 +29,13 @@ const UserProfile = ({
       className
     )}
   >
-    <Avatar src={avatarSrc} alt={name} size={24} />
-    <span className={clsx('text-16 font-normal text-gray-900')}>{name}</span>
+    <Avatar src={avatarSrc} alt={name} size={32} />
+    <div className={clsx('flex flex-col leading-tight')}>
+      <span className={clsx('text-14 font-normal text-gray-900')}>{name}</span>
+      <span className={clsx('text-12 font-normal text-gray-900 truncate max-w-120')}>
+        {company.name}
+      </span>
+    </div>
   </Link>
 );
 


### PR DESCRIPTION
## 📝 변경사항
UserProfile 컴포넌트의 네이밍과 인터페이스를 정리하고, 회사 정보 표시를 위해 `company` prop을 추가했습니다.  
프로필 섹션의 레이아웃도 함께 개선하여 가독성과 일관성을 높였습니다.

## 🔨 작업 내용
- [x] `UseProfile` 폴더 및 파일명을 `UserProfile`로 변경
- [x] 컴포넌트명 `UseProfile` → `UserProfile`로 통일
- [x] `UserProfileProps`에 `company` prop 추가
- [x] 프로필 레이아웃 개선 (아바타 크기 조정, 이름과 회사명을 세로 방향으로 배치)
- [x] 관련 스토리 파일 및 import 경로 수정

## 🧪 테스트 방법
1. Storybook에서 `UserProfile` 컴포넌트를 열어 레이아웃이 정상적으로 표시되는지 확인
2. `name`, `email`, `company`를 각각 다른 값으로 전달했을 때 UI에 올바르게 반영되는지 확인
3. 기존 `UseProfile`를 사용하던 위치에서 import 경로 변경 후 빌드/타입 에러가 없는지 확인

## 📸 스크린샷 (UI 변경 시)
| Before | After  |
| ------ | ------ |
| <img width="94" height="39" alt="Screenshot 2025-12-09 at 10 21 13 AM" src="https://github.com/user-attachments/assets/9fdbd9cb-6fbf-479e-809b-50ae3491cbdf" /> | <img width="144" height="49" alt="Screenshot 2025-12-09 at 10 20 09 AM" src="https://github.com/user-attachments/assets/25f1ac38-0f75-4cda-b99a-ba6c6840adc8" /> |

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다  
- [x] 주요 로직에 주석을 작성했습니다  
- [x] 테스트 코드를 작성했습니다  
- [x] 문서를 업데이트했습니다 (필요 시)  
- [x] 이슈를 연결했습니다  

## 🔗 관련 이슈
Closes #21 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 프로필에 회사 정보 표시 기능 추가

* **스타일**
  * 프로필 이미지 크기 증가
  * 사용자 정보 레이아웃 개선 (이름과 회사 정보를 별도의 두 줄로 표시)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->