### PR TITLE
feat: refactor global header layout with HeaderShell and AuthHeader

### DIFF
--- a/src/app/[companyId]/layout.tsx
+++ b/src/app/[companyId]/layout.tsx
@@ -1,4 +1,3 @@
-// app/[companyId]/layout.tsx
 import type { Metadata } from 'next';
 
 interface Company {
@@ -8,14 +7,21 @@ interface Company {
 // 회사 정보 fetch 함수
 async function fetchCompanyById(companyId: string): Promise<Company> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/companies/${companyId}`, {
-    cache: 'force-cache', // 캐싱 전략
+    next: { revalidate: 3600 },
   });
 
   if (!res.ok) {
+    if (res.status === 404) {
+      // eslint-disable-next-line no-console
+      console.warn(`Company ${companyId} not found, using fallback`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(`Failed to fetch company ${companyId}: ${res.status} ${res.statusText}`);
+    }
     return { name: 'SNACK' }; // fallback
   }
 
-  return res.json() as Promise<Company>;
+  return (await res.json()) as Company;
 }
 
 // 동적 메타데이터 생성

--- a/src/app/[companyId]/layout.tsx
+++ b/src/app/[companyId]/layout.tsx
@@ -1,10 +1,40 @@
-import { ReactNode } from 'react';
+// app/[companyId]/layout.tsx
+import type { Metadata } from 'next';
 
-const Companylayout = ({ children }: { children: ReactNode }) => (
-  <div>
-    <p>Companylayout- 회사 레이아웃 페이지</p>
-    {children}
-  </div>
+interface Company {
+  name: string;
+}
+
+// 👇 회사 정보 fetch 함수
+async function fetchCompanyById(companyId: string): Promise<Company> {
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/companies/${companyId}`, {
+    cache: 'force-cache', // 캐싱 전략
+  });
+
+  if (!res.ok) {
+    return { name: 'SNACK' }; // fallback
+  }
+
+  return res.json() as Promise<Company>;
+}
+
+// 동적 메타데이터 생성
+export async function generateMetadata({
+  params,
+}: {
+  params: { companyId: string };
+}): Promise<Metadata> {
+  // 백엔드에서 회사 정보 가져오기
+  const company = await fetchCompanyById(params.companyId);
+
+  return {
+    title: `${company.name}의 SNACK - 회사 간식 구매 관리 솔루션`,
+    description: `${company.name}의 간식 구매 내역을 한 곳에서 통합 관리하세요. 구매 기록, 예산, 카테고리별 상품 데이터를 손쉽게 확인할 수 있습니다.`,
+  };
+}
+
+const CompanyLayout = ({ children }: { children: React.ReactNode }) => (
+  <main className="container mx-auto">{children}</main>
 );
 
-export default Companylayout;
+export default CompanyLayout;

--- a/src/app/[companyId]/layout.tsx
+++ b/src/app/[companyId]/layout.tsx
@@ -22,10 +22,11 @@ async function fetchCompanyById(companyId: string): Promise<Company> {
 export async function generateMetadata({
   params,
 }: {
-  params: { companyId: string };
+  params: Promise<{ companyId: string }>;
 }): Promise<Metadata> {
+  const { companyId } = await params;
   // 백엔드에서 회사 정보 가져오기
-  const company = await fetchCompanyById(params.companyId);
+  const company = await fetchCompanyById(companyId);
 
   return {
     title: `${company.name}의 SNACK - 회사 간식 구매 관리 솔루션`,

--- a/src/app/[companyId]/layout.tsx
+++ b/src/app/[companyId]/layout.tsx
@@ -5,7 +5,7 @@ interface Company {
   name: string;
 }
 
-// 👇 회사 정보 fetch 함수
+// 회사 정보 fetch 함수
 async function fetchCompanyById(companyId: string): Promise<Company> {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/companies/${companyId}`, {
     cache: 'force-cache', // 캐싱 전략
@@ -30,7 +30,7 @@ export async function generateMetadata({
 
   return {
     title: `${company.name}의 SNACK - 회사 간식 구매 관리 솔루션`,
-    description: `${company.name}의 간식 구매 내역을 한 곳에서 통합 관리하세요. 구매 기록, 예산, 카테고리별 상품 데이터를 손쉽게 확인할 수 있습니다.`,
+    description: `${company.name}의 간식 구매 내역을 한 곳에서 통합 관리하세요. 구매 기록, 예산, 카테고리별 상품 데이터를 손쉽게 확인할 수 있습니다`,
   };
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import HeaderShell from '@/components/organisms/HeaderShell/HeaderShell';
 import { Providers } from './providers';
 import './globals.css';
 import { suit } from './fonts';
@@ -16,7 +17,10 @@ const RootLayout = ({
 }>) => (
   <html lang="ko">
     <body className={`${suit.variable} font-sans`}>
-      <Providers>{children}</Providers>
+      <Providers>
+        <HeaderShell />
+        {children}
+      </Providers>
     </body>
   </html>
 );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,4 +8,3 @@ const Home = () => (
 );
 
 export default Home;
-

--- a/src/components/molecules/AuthUserActions/AuthUserActions.tsx
+++ b/src/components/molecules/AuthUserActions/AuthUserActions.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import React from 'react';
+import Link from 'next/link';
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+
+import { clsx } from '@/utils/clsx';
+import { IconButton } from '@/components/atoms/IconButton/IconButton';
+
+/**
+ * Mobile 전용 Props
+ * - 로그인, 기업가입 (짧은 텍스트)
+ */
+export interface AuthUserActionsMobileProps {
+  className?: string;
+}
+
+/**
+ * Tablet 전용 Props
+ * - 로그인, 기업 담당자 회원가입
+ */
+export interface AuthUserActionsTabletProps {
+  className?: string;
+}
+
+/**
+ * Desktop 전용 Props
+ * - 로그인, 기업 담당자 회원가입
+ */
+export interface AuthUserActionsDesktopProps {
+  className?: string;
+}
+
+// Mobile Component
+export const AuthUserActionsMobile: React.FC<AuthUserActionsMobileProps> = ({ className }) => {
+  const pathname = usePathname();
+  const isLoginPage = pathname?.startsWith('/login');
+  const isSignupPage = pathname?.startsWith('/signup');
+
+  return (
+    <div className={clsx('flex items-center gap-8', className)}>
+      {!isLoginPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/login"
+        >
+          <IconButton aria-label="로그인" size="md" variant="default">
+            <Image alt="Login" height={24} src="/icons/lock.svg" width={24} />
+          </IconButton>
+          로그인
+        </Link>
+      )}
+      {!isSignupPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/signup"
+        >
+          <IconButton aria-label="기업가입" size="md" variant="default">
+            <Image alt="Signup" height={24} src="/icons/user-manager.svg" width={24} />
+          </IconButton>
+          기업가입
+        </Link>
+      )}
+    </div>
+  );
+};
+
+// Tablet Component
+export const AuthUserActionsTablet: React.FC<AuthUserActionsTabletProps> = ({ className }) => {
+  const pathname = usePathname();
+  const isLoginPage = pathname?.startsWith('/login');
+  const isSignupPage = pathname?.startsWith('/signup');
+
+  return (
+    <div className={clsx('flex items-center gap-12', className)}>
+      {!isLoginPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/login"
+        >
+          <IconButton aria-label="로그인" size="md" variant="default">
+            <Image alt="Login" height={24} src="/icons/lock.svg" width={24} />
+          </IconButton>
+          로그인
+        </Link>
+      )}
+      {!isSignupPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/signup"
+        >
+          <IconButton aria-label="기업 담당자 회원가입" size="md" variant="default">
+            <Image alt="Signup" height={24} src="/icons/user-manager.svg" width={24} />
+          </IconButton>
+          기업 담당자 회원가입
+        </Link>
+      )}
+    </div>
+  );
+};
+
+// Desktop Component
+export const AuthUserActionsDesktop: React.FC<AuthUserActionsDesktopProps> = ({ className }) => {
+  const pathname = usePathname();
+  const isLoginPage = pathname?.startsWith('/login');
+  const isSignupPage = pathname?.startsWith('/signup');
+
+  return (
+    <div className={clsx('flex items-center gap-16', className)}>
+      {!isLoginPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/login"
+        >
+          <IconButton aria-label="로그인" size="md" variant="default">
+            <Image alt="Login" height={24} src="/icons/lock.svg" width={24} />
+          </IconButton>
+          로그인
+        </Link>
+      )}
+      {!isSignupPage && (
+        <Link
+          className="flex items-center gap-8 text-16 text-gray-700 hover:text-gray-950"
+          href="/signup"
+        >
+          <IconButton aria-label="기업 담당자 회원가입" size="md" variant="default">
+            <Image alt="Signup" height={24} src="/icons/user-manager.svg" width={24} />
+          </IconButton>
+          기업 담당자 회원가입
+        </Link>
+      )}
+    </div>
+  );
+};
+
+// Main AuthUserActions Component (통합 컴포넌트)
+export interface AuthUserActionsProps {
+  className?: string;
+}
+
+/**
+ * AuthUserActions
+ *
+ * 반응형 인증 사용자 액션 컴포넌트
+ * - 모바일: 로그인, 기업가입 (짧은 텍스트)
+ * - 태블릿: 로그인, 기업 담당자 회원가입
+ * - 데스크탑: 로그인, 기업 담당자 회원가입
+ */
+export const AuthUserActions: React.FC<AuthUserActionsProps> = ({ className }) => (
+  <>
+    {/* 모바일 */}
+    <div className={clsx('tablet:hidden', className)}>
+      <AuthUserActionsMobile />
+    </div>
+
+    {/* 태블릿 (744px ~ 1199px) */}
+    <div className={clsx('hidden tablet:flex desktop:hidden', className)}>
+      <AuthUserActionsTablet />
+    </div>
+
+    {/* 데스크탑 */}
+    <div className={clsx('hidden desktop:flex', className)}>
+      <AuthUserActionsDesktop />
+    </div>
+  </>
+);

--- a/src/components/organisms/AuthHeader/AuthHeader.stories.tsx
+++ b/src/components/organisms/AuthHeader/AuthHeader.stories.tsx
@@ -1,0 +1,233 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import AuthHeader from './AuthHeader';
+
+const meta = {
+  title: 'Organisms/AuthHeader',
+  component: AuthHeader,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    nextjs: {
+      appDirectory: true,
+      navigation: {
+        pathname: '/',
+        segments: [],
+      },
+    },
+    docs: {
+      description: {
+        component:
+          '인증되지 않은 사용자를 위한 헤더 컴포넌트입니다. 로그인 및 회원가입 링크를 제공하며, 현재 페이지에 따라 해당 링크를 숨깁니다. 모바일에서는 &quot;기업 담당자 회원가입&quot;이 &quot;기업가입&quot;으로 축약되어 표시됩니다.',
+      },
+      canvas: {
+        withToolbar: true,
+      },
+    },
+  },
+  argTypes: {
+    className: {
+      control: 'text',
+      description: '추가 CSS 클래스명',
+    },
+  },
+} satisfies Meta<typeof AuthHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof AuthHeader>;
+
+export const Default: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/',
+        segments: [],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          '홈 페이지에서 보이는 기본 헤더입니다. 로그인과 기업 담당자 회원가입 링크가 모두 표시됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-full min-h-screen bg-gray-50">
+      <AuthHeader className={args.className} />
+      <main className="p-24">
+        <div className="max-w-1200 mx-auto">
+          <h1 className="text-24 font-bold mb-16">AuthHeader 컴포넌트 예시</h1>
+          <p className="text-16 text-gray-600 mb-8">
+            상단의 AuthHeader를 통해 로그인 및 회원가입 링크를 확인할 수 있습니다.
+          </p>
+          <div className="space-y-8">
+            <p className="text-14 text-gray-500">
+              - 현재 페이지가 로그인 페이지가 아니므로 로그인 링크가 표시됩니다.
+            </p>
+            <p className="text-14 text-gray-500">
+              - 현재 페이지가 회원가입 페이지가 아니므로 회원가입 링크가 표시됩니다.
+            </p>
+            <p className="text-14 text-gray-500">
+              - 데스크탑/태블릿: &quot;기업 담당자 회원가입&quot; 전체 텍스트 표시
+            </p>
+            <p className="text-14 text-gray-500">- 모바일: &quot;기업가입&quot;으로 축약 표시</p>
+          </div>
+        </div>
+      </main>
+    </div>
+  ),
+};
+
+export const OnLoginPage: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/login',
+        segments: ['login'],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          '로그인 페이지에서 보이는 헤더입니다. 로그인 링크는 숨겨지고 회원가입 링크만 표시됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-full min-h-screen bg-gray-50">
+      <AuthHeader className={args.className} />
+      <main className="p-24">
+        <div className="max-w-1200 mx-auto">
+          <h1 className="text-24 font-bold mb-16">로그인 페이지</h1>
+          <p className="text-16 text-gray-600 mb-8">
+            로그인 페이지에서는 로그인 링크가 숨겨지고 회원가입 링크만 표시됩니다.
+          </p>
+        </div>
+      </main>
+    </div>
+  ),
+};
+
+export const OnSignupPage: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/signup',
+        segments: ['signup'],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          '회원가입 페이지에서 보이는 헤더입니다. 회원가입 링크는 숨겨지고 로그인 링크만 표시됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-full min-h-screen bg-gray-50">
+      <AuthHeader className={args.className} />
+      <main className="p-24">
+        <div className="max-w-1200 mx-auto">
+          <h1 className="text-24 font-bold mb-16">회원가입 페이지</h1>
+          <p className="text-16 text-gray-600 mb-8">
+            회원가입 페이지에서는 회원가입 링크가 숨겨지고 로그인 링크만 표시됩니다.
+          </p>
+        </div>
+      </main>
+    </div>
+  ),
+};
+
+export const Mobile: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'mobile',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/',
+        segments: [],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          '모바일 뷰포트에서 보이는 헤더입니다. &quot;기업 담당자 회원가입&quot;이 &quot;기업가입&quot;으로 축약되어 표시됩니다.',
+      },
+      canvas: {
+        withToolbar: true,
+      },
+    },
+  },
+  render: (args) => (
+    <div className="w-full min-h-screen bg-gray-50">
+      <AuthHeader className={args.className} />
+      <main className="p-16">
+        <div className="max-w-1200 mx-auto">
+          <h1 className="text-20 font-bold mb-12">모바일 뷰</h1>
+          <p className="text-14 text-gray-600 mb-8">
+            모바일에서는 텍스트가 축약되어 표시됩니다: &quot;기업가입&quot;
+          </p>
+        </div>
+      </main>
+    </div>
+  ),
+};
+
+export const Tablet: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'tablet',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/',
+        segments: [],
+      },
+    },
+    docs: {
+      description: {
+        story: '태블릿 뷰포트에서 보이는 헤더입니다. 전체 텍스트가 표시됩니다.',
+      },
+      canvas: {
+        withToolbar: true,
+      },
+    },
+  },
+  render: Default.render,
+};
+
+export const Desktop: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: 'desktop',
+    },
+    nextjs: {
+      navigation: {
+        pathname: '/',
+        segments: [],
+      },
+    },
+    docs: {
+      description: {
+        story: '데스크탑 뷰포트에서 보이는 헤더입니다. 전체 텍스트가 표시됩니다.',
+      },
+      canvas: {
+        withToolbar: true,
+      },
+    },
+  },
+  render: Default.render,
+};

--- a/src/components/organisms/AuthHeader/AuthHeader.tsx
+++ b/src/components/organisms/AuthHeader/AuthHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import React from 'react';
+
+import { clsx } from '@/utils/clsx';
+import GNBBrand from '@/components/molecules/GNBBrand/GNBBrand';
+import { AuthUserActions } from '@/components/molecules/AuthUserActions/AuthUserActions';
+
+interface AuthHeaderProps {
+  className?: string;
+}
+
+const AuthHeader: React.FC<AuthHeaderProps> = ({ className }) => (
+  <header
+    className={clsx(
+      'sticky top-0 z-header',
+      'w-full h-56',
+      'bg-white border-b border-gray-200',
+      'flex items-center justify-between',
+      'px-16 tablet:px-24 desktop:px-32',
+      className
+    )}
+  >
+    {/* 왼쪽: Brand (기존 Molecule 재사용) */}
+    <div className="flex items-center shrink-0">
+      <GNBBrand />
+    </div>
+
+    {/* 오른쪽: Auth User Actions */}
+    <AuthUserActions />
+  </header>
+);
+
+export default AuthHeader;

--- a/src/components/organisms/AuthHeader/AuthHeader.tsx
+++ b/src/components/organisms/AuthHeader/AuthHeader.tsx
@@ -11,7 +11,7 @@ interface AuthHeaderProps {
 }
 
 const AuthHeader: React.FC<AuthHeaderProps> = ({ className }) => (
-  <header
+  <div
     className={clsx(
       'sticky top-0 z-header',
       'w-full h-56',
@@ -28,7 +28,7 @@ const AuthHeader: React.FC<AuthHeaderProps> = ({ className }) => (
 
     {/* 오른쪽: Auth User Actions */}
     <AuthUserActions />
-  </header>
+  </div>
 );
 
 export default AuthHeader;

--- a/src/components/organisms/GNB/GNB.tsx
+++ b/src/components/organisms/GNB/GNB.tsx
@@ -123,7 +123,7 @@ const GNB: React.FC<GNBProps> = ({
   };
 
   return (
-    <header
+    <div
       className={clsx(
         'sticky top-0 z-header',
         'w-full h-56',
@@ -185,7 +185,7 @@ const GNB: React.FC<GNBProps> = ({
           />
         </SideBarMenu>
       </div>
-    </header>
+    </div>
   );
 };
 

--- a/src/components/organisms/GNB/GNBWrapper.tsx
+++ b/src/components/organisms/GNB/GNBWrapper.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuthStore } from '@/lib/store/authStore';
+import GNB from './GNB';
+
+/**
+ * GNBWrapper
+ *
+ * GNB를 실제 서비스 맥락에 맞게 동작시키는 컨트롤러
+ * - 인증 상태 조회 및 role 주입
+ * - 로그아웃 핸들러
+ * - Cart count, User profile 등 데이터 주입
+ */
+export const GNBWrapper: React.FC = () => {
+  const { user, clearAuth } = useAuthStore();
+  const router = useRouter();
+
+  // 로그아웃 핸들러
+  const handleLogout = () => {
+    clearAuth();
+    router.push('/login');
+  };
+
+  // TODO: Cart API 연결 후 실제 데이터로 교체
+  // const { data: cartData } = useCartQuery();
+  // const cartCount = cartData?.totalItems || 0;
+
+  // TODO: UserProfile 컴포넌트 구현 후 추가
+  // const userProfile = user ? (
+  //   <UserProfileAvatar
+  //     name={user.name}
+  //     avatar={user.avatar}
+  //   />
+  // ) : null;
+
+  // TODO: 상품 페이지에서 Category 관련 로직 추가
+  // const pathname = usePathname();
+  // const isProductPage = pathname?.includes('/products');
+  // const categoryProps = isProductPage ? {
+  //   categories: PARENT_CATEGORIES,
+  //   activeCategoryId: currentCategory,
+  //   onCategoryChange: handleCategoryChange,
+  // } : {};
+
+  return (
+    <GNB
+      role={user?.role || 'user'}
+      cartCount={0}
+      onLogout={handleLogout}
+      // userProfile={userProfile}
+      // {...categoryProps}
+    />
+  );
+};
+
+export default GNBWrapper;

--- a/src/components/organisms/HeaderShell/HeaderShell.tsx
+++ b/src/components/organisms/HeaderShell/HeaderShell.tsx
@@ -1,0 +1,44 @@
+// src/components/organisms/HeaderShell/HeaderShell.tsx
+
+'use client';
+
+import React, { useMemo } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { clsx } from '@/utils/clsx';
+import AuthHeader from '@/components/organisms/AuthHeader/AuthHeader';
+import GNBWrapper from '@/components/organisms/GNB/GNBWrapper';
+
+interface HeaderShellProps {
+  className?: string;
+}
+
+const AUTH_HEADER_MATCHERS = [
+  /^\/$/, // home
+  /^\/login(?:\/|$)/,
+  /^\/invite(?:\/|$)/,
+];
+
+const HIDDEN_HEADER_ROUTES = [/^\/signup(?:\/|$)/];
+
+export const HeaderShell: React.FC<HeaderShellProps> = ({ className }) => {
+  const pathname = usePathname();
+
+  const isAuthRoute = useMemo(() => {
+    if (!pathname) return false;
+    return AUTH_HEADER_MATCHERS.some((re) => re.test(pathname));
+  }, [pathname]);
+
+  const shouldHideHeader = useMemo(() => {
+    if (!pathname) return false;
+    return HIDDEN_HEADER_ROUTES.some((re) => re.test(pathname));
+  }, [pathname]);
+
+  if (shouldHideHeader) return null;
+
+  return (
+    <header className={clsx(className)}>{isAuthRoute ? <AuthHeader /> : <GNBWrapper />}</header>
+  );
+};
+
+export default HeaderShell;


### PR DESCRIPTION
## 변경사항
전역 레이아웃 구조를 리팩토링하여 헤더 렌더링 책임을 통합 관리하도록 개선했습니다.  
경로 및 인증 상태에 따라 AuthHeader와 GNB를 명확히 분리하고,  
중복 헤더 렌더링 문제를 해결했습니다.

##  작업 내용
### 1. HeaderShell 도입 (전역 헤더 컨트롤러)
- [x] HeaderShell 컴포넌트 추가
- [x] 현재 경로 기준으로 AuthHeader / GNBWrapper를 조건부 렌더링
- [x] 헤더 관련 분기 로직을 단일 컴포넌트로 집중 관리

### 2. AuthHeader 및 인증 관련 UI 추가
- [x] AuthHeader 컴포넌트 추가
  - 인증되지 않은 사용자용 헤더
  - 로그인 / 회원가입 링크 제공
- [x] AuthUserActions 컴포넌트 추가
  - 반응형 인증 액션 UI
  - 모바일 환경에서 텍스트 축약 처리

### 3. GNBWrapper 추가
- [x] GNBWrapper 컴포넌트 추가
- [x] GNB를 실제 서비스 맥락(회사 스코프, 사용자 상태)에 맞게 제어
- [x] 헤더 레벨에서 GNB 관련 로직 분리

### 4. 레이아웃 구조 정리
- [x] Root Layout에서 HeaderShell 사용하도록 변경
- [x] `[companyId]` 레이아웃에서 중복 헤더 제거
- [x] `[companyId]` 레이아웃에 동적 메타데이터 생성 로직 추가

## 테스트 방법
1. 로그인/회원가입 페이지 접근 시 AuthHeader가 정상 표시되는지 확인  
2. 인증 후 `[companyId]` 경로 진입 시 GNB가 정상 렌더링되는지 확인  
3. 페이지 이동 시 헤더가 중복 렌더링되지 않는지 확인  
4. 모바일/태블릿/데스크탑에서 AuthUserActions 반응형 동작 확인  
5. `[companyId]` 레이아웃에서 메타데이터가 정상적으로 생성되는지 확인  

## 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다  
- [x] 주요 로직에 주석을 작성했습니다  
- [x] 테스트 코드를 작성했습니다  
- [x] 문서를 업데이트했습니다 (필요 시)  
- [x] 이슈를 연결했습니다  

## 🔗 관련 이슈
Closes #71 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 모바일·태블릿·데스크톱에 최적화된 반응형 헤더 UI 추가
  * 경로에 따라 인증용 헤더와 일반 헤더를 동적으로 전환하고 특정 경로에서 헤더 숨김
  * 로그인·회원가입 링크의 노출을 페이지별로 제어하는 인증 액션 컴포넌트 추가
  * 앱 레이아웃에 헤더 셸을 통합해 모든 페이지에 헤더 적용
  * 회사 정보 기반으로 페이지 타이틀·설명을 자동 생성하는 동적 메타데이터 지원
  * 헤더용 Storybook 예제 및 로그아웃 처리 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->