### PR TITLE
Feat: Build and Refactor user's profile feature (Pages, Sections, and Integration)

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-// eslint-disable-next-line import/extensions
-import './.next/dev/types/routes.d.ts';
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes';
+// eslint-disable-next-line import/extensions
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[companyId]/my/profile/page.tsx
+++ b/src/app/[companyId]/my/profile/page.tsx
@@ -1,7 +1,5 @@
-const ProfilePage = () => (
-  <div>
-    <p>ProfilePage — 프로필 페이지</p>
-  </div>
-);
+import ProfileEditSection from '@/features/profile/section/ProfileEditSection';
+
+const ProfilePage = () => <ProfileEditSection />;
 
 export default ProfilePage;

--- a/src/components/atoms/Avatar/Avatar.tsx
+++ b/src/components/atoms/Avatar/Avatar.tsx
@@ -8,6 +8,7 @@ type AvatarBgColor = 'gray-100' | 'gray-50';
 export interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src?: string;
   alt?: string;
+  name?: string;
   size?: AvatarSize;
   bgColor?: AvatarBgColor;
 }
@@ -30,6 +31,7 @@ const bgColorClass: Record<AvatarBgColor, string> = {
 export const Avatar: React.FC<AvatarProps> = ({
   src,
   alt = 'avatar',
+  name,
   size = 32,
   bgColor = 'gray-100',
   className,
@@ -53,6 +55,15 @@ export const Avatar: React.FC<AvatarProps> = ({
   const renderContent = () => {
     if (src) {
       return <img src={src} alt={alt} className="h-full w-full object-cover rounded-full" />;
+    }
+    if (name) {
+      const firstChar = name.charAt(0).toUpperCase();
+      const fontSize = size === 24 ? 'text-10' : 'text-14';
+      return (
+        <span className={clsx('font-medium text-gray-950 tracking--0.25', fontSize)}>
+          {firstChar}
+        </span>
+      );
     }
     return (
       <Image

--- a/src/components/atoms/FloatingLabelInput/FloatingLabelInput.tsx
+++ b/src/components/atoms/FloatingLabelInput/FloatingLabelInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { forwardRef, useState } from 'react';
+import React, { forwardRef, useState, useId } from 'react';
 import { clsx } from '@/utils/clsx';
 
 export interface FloatingLabelInputProps extends Omit<
@@ -27,12 +27,12 @@ const FloatingLabelInput = forwardRef<HTMLInputElement, FloatingLabelInputProps>
     },
     ref
   ) => {
+    const generatedId = useId();
     const [showPassword, setShowPassword] = useState(false);
     const hasValue = value !== undefined && value !== '';
     const isDisabled = props.disabled;
 
-    // Generate a unique ID if one isn't provided
-    const inputId = id || `floating-input-${label.replace(/\s+/g, '-').toLowerCase()}`;
+    const inputId = id || generatedId;
 
     let inputType = type;
     if (showPasswordToggle) {

--- a/src/components/atoms/FloatingLabelInput/FloatingLabelInput.tsx
+++ b/src/components/atoms/FloatingLabelInput/FloatingLabelInput.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import React, { forwardRef, useState } from 'react';
+import { clsx } from '@/utils/clsx';
+
+export interface FloatingLabelInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'className'
+> {
+  label: string;
+  error?: boolean;
+  showPasswordToggle?: boolean;
+  className?: string;
+}
+
+const FloatingLabelInput = forwardRef<HTMLInputElement, FloatingLabelInputProps>(
+  (
+    {
+      className,
+      label,
+      error = false,
+      showPasswordToggle = false,
+      type = 'text',
+      value,
+      id,
+      ...props
+    },
+    ref
+  ) => {
+    const [showPassword, setShowPassword] = useState(false);
+    const hasValue = value !== undefined && value !== '';
+    const isDisabled = props.disabled;
+
+    // Generate a unique ID if one isn't provided
+    const inputId = id || `floating-input-${label.replace(/\s+/g, '-').toLowerCase()}`;
+
+    let inputType = type;
+    if (showPasswordToggle) {
+      inputType = showPassword ? 'text' : 'password';
+    }
+
+    const getBorderColor = () => {
+      if (error) return 'border-error-500';
+      if (isDisabled) return 'border-gray-200';
+      if (hasValue) return 'border-gray-950';
+      return 'border-gray-600';
+    };
+
+    const getTextColor = () => {
+      if (isDisabled) return 'text-gray-300 cursor-not-allowed';
+      if (hasValue) return 'text-gray-950';
+      return 'text-gray-500 placeholder:text-gray-500';
+    };
+
+    return (
+      <div
+        className={clsx(
+          'relative flex h-56 px-4 py-8',
+          'border-b border-t-0 border-l-0 border-r-0',
+          getBorderColor(),
+          hasValue || isDisabled ? 'flex-col justify-between' : 'items-center justify-between',
+          className
+        )}
+      >
+        {(hasValue || isDisabled) && (
+          <label
+            htmlFor={inputId}
+            className={clsx(
+              'text-12 tracking--0.3 leading-normal',
+              isDisabled ? 'text-gray-500' : 'text-gray-600'
+            )}
+          >
+            {label}
+          </label>
+        )}
+        <div className="flex items-center justify-between w-full gap-4">
+          <input
+            ref={ref}
+            id={inputId}
+            type={inputType}
+            value={value}
+            placeholder={hasValue || isDisabled ? undefined : label}
+            className={clsx(
+              'flex-1 bg-transparent outline-none border-none p-0',
+              'text-16 tracking--0.4 leading-normal',
+              getTextColor()
+            )}
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...props}
+          />
+          {showPasswordToggle && !isDisabled && (
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="flex items-center justify-center w-20 h-20 shrink-0"
+              aria-label={showPassword ? '비밀번호 숨기기' : '비밀번호 보기'}
+            >
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                {showPassword ? (
+                  <>
+                    <path
+                      d="M2.5 10C2.5 10 5 4.16667 10 4.16667C15 4.16667 17.5 10 17.5 10C17.5 10 15 15.8333 10 15.8333C5 15.8333 2.5 10 2.5 10Z"
+                      stroke="#666666"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M10 12.5C11.3807 12.5 12.5 11.3807 12.5 10C12.5 8.61929 11.3807 7.5 10 7.5C8.61929 7.5 7.5 8.61929 7.5 10C7.5 11.3807 8.61929 12.5 10 12.5Z"
+                      stroke="#666666"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </>
+                ) : (
+                  <>
+                    <path
+                      d="M2.5 2.5L17.5 17.5"
+                      stroke="#666666"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                    <path
+                      d="M8.82 8.82C8.42848 9.21151 8.20312 9.74696 8.20312 10.305C8.20312 10.863 8.42848 11.3985 8.82 11.79C9.21151 12.1815 9.74696 12.4069 10.305 12.4069C10.863 12.4069 11.3985 12.1815 11.79 11.79"
+                      stroke="#666666"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M14.4167 14.4167C13.0833 15.4167 11.5833 15.8333 10 15.8333C5 15.8333 2.5 10 2.5 10C3.25 8.41667 4.25 7.08333 5.58333 5.58333M8.33333 4.58333C8.88333 4.41667 9.43333 4.16667 10 4.16667C15 4.16667 17.5 10 17.5 10C17.0833 10.9167 16.5833 11.75 16 12.5"
+                      stroke="#666666"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </>
+                )}
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+FloatingLabelInput.displayName = 'FloatingLabelInput';
+
+export default FloatingLabelInput;

--- a/src/components/molecules/RHFFloatingLabelInput/RHFFloatingLabelInput.tsx
+++ b/src/components/molecules/RHFFloatingLabelInput/RHFFloatingLabelInput.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { type Control, type FieldValues, type Path, Controller } from 'react-hook-form';
+import FloatingLabelInput from '@/components/atoms/FloatingLabelInput/FloatingLabelInput';
+import { clsx } from '@/utils/clsx';
+
+interface RHFFloatingLabelInputProps<T extends FieldValues> {
+  control: Control<T>;
+  name: Path<T>;
+  label: string;
+  type?: 'text' | 'email' | 'password';
+  disabled?: boolean;
+  showPasswordToggle?: boolean;
+  className?: string;
+  errorLines?: number;
+}
+
+const RHFFloatingLabelInput = <T extends FieldValues>({
+  control,
+  name,
+  label,
+  type = 'text',
+  disabled,
+  showPasswordToggle = false,
+  className,
+  errorLines = 1,
+}: RHFFloatingLabelInputProps<T>) => {
+  const errorSlotHeight = errorLines === 1 ? 'h-24' : 'h-48';
+  const errorSlotClassName = clsx(
+    'flex items-start',
+    'text-14 text-error-500 tracking--0.35',
+    errorSlotHeight
+  );
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <div className={className}>
+          <FloatingLabelInput
+            label={label}
+            type={type}
+            value={(field.value ?? '') as string}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            disabled={disabled}
+            showPasswordToggle={showPasswordToggle}
+            error={!!fieldState.error}
+          />
+          <div className={errorSlotClassName} aria-live="polite">
+            {fieldState.error?.message ?? '\u00A0'}
+          </div>
+        </div>
+      )}
+    />
+  );
+};
+
+export default RHFFloatingLabelInput;

--- a/src/components/molecules/RHFFloatingLabelInput/RHFFloatingLabelInput.tsx
+++ b/src/components/molecules/RHFFloatingLabelInput/RHFFloatingLabelInput.tsx
@@ -4,9 +4,9 @@ import { type Control, type FieldValues, type Path, Controller } from 'react-hoo
 import FloatingLabelInput from '@/components/atoms/FloatingLabelInput/FloatingLabelInput';
 import { clsx } from '@/utils/clsx';
 
-interface RHFFloatingLabelInputProps<T extends FieldValues> {
+interface RHFFloatingLabelInputProps<T extends FieldValues, TName extends Path<T> = Path<T>> {
   control: Control<T>;
-  name: Path<T>;
+  name: TName;
   label: string;
   type?: 'text' | 'email' | 'password';
   disabled?: boolean;
@@ -41,7 +41,7 @@ const RHFFloatingLabelInput = <T extends FieldValues>({
           <FloatingLabelInput
             label={label}
             type={type}
-            value={(field.value ?? '') as string}
+            value={String(field.value ?? '')}
             onChange={field.onChange}
             onBlur={field.onBlur}
             disabled={disabled}

--- a/src/components/molecules/UserProfile/UserProfile.tsx
+++ b/src/components/molecules/UserProfile/UserProfile.tsx
@@ -34,7 +34,7 @@ export const UserProfileMobile: React.FC<UserProfileBaseProps> = ({
     aria-label={`View ${name}'s profile`}
     className={clsx('flex items-center gap-8 hover:opacity-80 transition-opacity', className)}
   >
-    <Avatar src={avatarSrc} alt={name} size={32} />
+    <Avatar src={avatarSrc} alt={name} name={name} size={32} />
   </Link>
 );
 
@@ -51,7 +51,7 @@ export const UserProfileTablet: React.FC<UserProfileBaseProps> = ({
     aria-label={`View ${name}'s profile`}
     className={clsx('flex items-center gap-8 hover:opacity-80 transition-opacity', className)}
   >
-    <Avatar src={avatarSrc} alt={name} size={32} />
+    <Avatar src={avatarSrc} alt={name} name={name} size={32} />
     <div className={clsx('flex flex-col leading-tight')}>
       <span className={clsx('text-14 font-normal text-gray-900')}>{name}</span>
       <span className={clsx('text-12 font-normal text-gray-900 truncate max-w-120')}>
@@ -74,7 +74,7 @@ export const UserProfileDesktop: React.FC<UserProfileBaseProps> = ({
     aria-label={`View ${name}'s profile`}
     className={clsx('flex items-center gap-8 hover:opacity-80 transition-opacity', className)}
   >
-    <Avatar src={avatarSrc} alt={name} size={32} />
+    <Avatar src={avatarSrc} alt={name} name={name} size={32} />
     <div className={clsx('flex flex-col leading-tight')}>
       <span className={clsx('text-14 font-normal text-gray-900')}>{name}</span>
       <span className={clsx('text-12 font-normal text-gray-900 truncate max-w-120')}>
@@ -98,7 +98,7 @@ export const UserProfileDefault: React.FC<UserProfileBaseProps> = ({
     aria-label={`View ${name}'s profile`}
     className={clsx('flex items-center gap-8 hover:opacity-80 transition-opacity', className)}
   >
-    <Avatar src={avatarSrc} alt={name} size={32} />
+    <Avatar src={avatarSrc} alt={name} name={name} size={32} />
     <div className={clsx('flex flex-col leading-tight')}>
       <span className={clsx('text-15 font-normal text-gray-900')}>{name}</span>
       <span className={clsx('text-12 font-normal text-gray-900 truncate max-w-120')}>
@@ -121,7 +121,7 @@ export const UserProfileNameOnly: React.FC<UserProfileBaseProps> = ({
     aria-label={`View ${name}'s profile`}
     className={clsx('flex items-center gap-8 hover:opacity-80 transition-opacity', className)}
   >
-    <Avatar src={avatarSrc} alt={name} size={32} />
+    <Avatar src={avatarSrc} alt={name} name={name} size={32} />
     <span className={clsx('text-14 tablet:text-16 font-normal text-gray-900')}>{name}</span>
   </Link>
 );

--- a/src/features/auth/api/auth.api.ts
+++ b/src/features/auth/api/auth.api.ts
@@ -207,6 +207,7 @@ export async function login(credentials: LoginInput): Promise<{ user: User; acce
     user: {
       id: result.data.user.id,
       email: result.data.user.email,
+      name: result.data.user.name,
       role: normalizeRole(result.data.user.role),
       companyId: result.data.user.companyId,
     },
@@ -354,6 +355,7 @@ export async function signup(
     user: {
       id: result.data.user.id,
       email: result.data.user.email,
+      name: result.data.user.name,
       role: normalizeRole(result.data.user.role),
       companyId: result.data.user.companyId,
     },
@@ -572,6 +574,7 @@ export async function inviteSignup(
     user: {
       id: result.data.user.id,
       email: result.data.user.email,
+      name: result.data.user.name,
       role: normalizeRole(result.data.user.role),
       companyId: result.data.user.companyId,
     },

--- a/src/features/auth/schemas/login.schema.ts
+++ b/src/features/auth/schemas/login.schema.ts
@@ -5,6 +5,7 @@ import { UserRole } from '@/constants/roles';
 export const userSchema = z.object({
   id: z.string().min(1, '사용자 ID가 필요합니다.'),
   email: z.string().min(1, '이메일이 필요합니다.').email('올바른 이메일 형식이 아닙니다.'),
+  name: z.string().min(1, '사용자 이름이 필요합니다.'),
   role: z.enum(['user', 'manager', 'admin'], {
     message: '이 페이지에 접근할 권한이 없습니다.',
   }) as z.ZodType<UserRole>,

--- a/src/features/profile/api/company.api.ts
+++ b/src/features/profile/api/company.api.ts
@@ -1,0 +1,63 @@
+import { getApiUrl, getApiTimeout } from '@/utils/api';
+
+/**
+ * 회사 정보 인터페이스
+ */
+export interface Company {
+  id: string;
+  name: string;
+}
+
+/**
+ * 회사 정보 조회 API 응답 형식
+ */
+interface CompanyApiResponse {
+  success: boolean;
+  data: Company;
+  message: string;
+}
+
+/**
+ * 현재 로그인한 사용자의 회사 정보 조회
+ * - 엔드포인트: GET /api/v1/company
+ * - 로그인한 사용자의 회사 정보를 반환
+ * - Authorization 헤더에 JWT 토큰 필요
+ *
+ * @param accessToken - JWT 액세스 토큰
+ * @returns 회사 정보 (id, name)
+ * @throws {Error} 인증 실패 또는 서버 오류 시
+ */
+export async function getCompany(accessToken: string): Promise<Company> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(`${apiUrl}/api/v1/company`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      throw new Error('회사 정보를 가져오는데 실패했습니다.');
+    }
+
+    const result = (await response.json()) as CompanyApiResponse;
+    return result.data;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}

--- a/src/features/profile/api/profile.api.ts
+++ b/src/features/profile/api/profile.api.ts
@@ -1,0 +1,330 @@
+import { getApiUrl, getApiTimeout } from '@/utils/api';
+
+/**
+ * 프로필 업데이트 입력 데이터 (레거시)
+ */
+export interface UpdateProfileInput {
+  companyName: string;
+  password?: string;
+}
+
+/**
+ * 프로필 업데이트 응답 데이터 (레거시)
+ */
+export interface UpdateProfileResponse {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+}
+
+/**
+ * 관리자 프로필 업데이트 입력 데이터
+ * - 회사명과 비밀번호를 선택적으로 변경 가능
+ */
+export interface UpdateAdminProfileInput {
+  companyName?: string;
+  password?: string;
+}
+
+/**
+ * 일반 사용자/매니저 프로필 업데이트 입력 데이터
+ * - 비밀번호만 변경 가능
+ */
+export interface UpdateUserProfileInput {
+  password?: string;
+}
+
+/**
+ * API 에러 응답 형식
+ */
+interface ApiErrorResponse {
+  success: boolean;
+  message: string;
+  errorCode?: string;
+}
+
+/**
+ * API 성공 응답 형식 (제네릭)
+ */
+interface ApiSuccessResponse<T> {
+  success: boolean;
+  data: T;
+  message?: string;
+}
+
+export async function updateProfile(
+  userId: string,
+  data: UpdateProfileInput
+): Promise<UpdateProfileResponse> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const requestBody: { companyName: string; password?: string } = {
+      companyName: data.companyName,
+    };
+
+    // 비밀번호가 입력된 경우에만 포함
+    if (data.password && data.password.trim() !== '') {
+      requestBody.password = data.password;
+    }
+
+    const response = await fetch(`${apiUrl}/api/users/${userId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+      throw new Error(errorData?.message || '프로필 변경에 실패했습니다.');
+    }
+
+    const result = (await response.json()) as ApiSuccessResponse<UpdateProfileResponse>;
+    return result.data;
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}
+
+export async function updateCompanyName(companyId: string, companyName: string): Promise<void> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(`${apiUrl}/api/companies/${companyId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: companyName }),
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('[updateCompanyName] API 에러:', {
+          status: response.status,
+          statusText: response.statusText,
+          errorData,
+          url: `${apiUrl}/api/companies/${companyId}`,
+        });
+      }
+
+      throw new Error(errorData?.message || `기업명 변경에 실패했습니다. (${response.status})`);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}
+
+export async function updatePassword(userId: string, password: string): Promise<void> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(`${apiUrl}/api/users/${userId}/password`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password }),
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('[updatePassword] API 에러:', {
+          status: response.status,
+          statusText: response.statusText,
+          errorData,
+          url: `${apiUrl}/api/users/${userId}/password`,
+        });
+      }
+
+      throw new Error(errorData?.message || `비밀번호 변경에 실패했습니다. (${response.status})`);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * 관리자 프로필 업데이트
+ * - 엔드포인트: PATCH /api/v1/user/admin/profile
+ * - 권한: ADMIN만 사용 가능
+ * - 회사명과 비밀번호를 선택적으로 변경 가능
+ *
+ * @param data - 변경할 프로필 데이터 (companyName, password 중 하나 이상 필수)
+ * @param accessToken - JWT 액세스 토큰
+ * @throws {Error} 인증 실패, 권한 없음, 또는 서버 오류 시
+ */
+export async function updateAdminProfile(
+  data: UpdateAdminProfileInput,
+  accessToken: string
+): Promise<void> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const requestBody: { companyName?: string; password?: string } = {};
+
+    if (data.companyName && data.companyName.trim() !== '') {
+      requestBody.companyName = data.companyName;
+    }
+
+    if (data.password && data.password.trim() !== '') {
+      requestBody.password = data.password;
+    }
+
+    const response = await fetch(`${apiUrl}/api/v1/user/admin/profile`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      let errorData: ApiErrorResponse | null = null;
+
+      try {
+        errorData = JSON.parse(responseText) as ApiErrorResponse;
+      } catch {
+        // Response is not JSON
+      }
+
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('[updateAdminProfile] API 에러:', {
+          status: response.status,
+          statusText: response.statusText,
+          errorData,
+          responseText,
+          requestBody,
+          url: `${apiUrl}/api/v1/user/admin/profile`,
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${accessToken.substring(0, 20)}...`,
+          },
+        });
+      }
+
+      throw new Error(errorData?.message || `프로필 변경에 실패했습니다. (${response.status})`);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}
+
+/**
+ * 일반 사용자/매니저 프로필 업데이트
+ * - 엔드포인트: PATCH /api/v1/user/me/profile
+ * - 권한: USER, MANAGER가 사용 가능
+ * - 비밀번호만 변경 가능
+ *
+ * @param data - 변경할 비밀번호 데이터
+ * @param accessToken - JWT 액세스 토큰
+ * @throws {Error} 인증 실패 또는 서버 오류 시
+ */
+export async function updateUserProfile(
+  data: UpdateUserProfileInput,
+  accessToken: string
+): Promise<void> {
+  const apiUrl = getApiUrl();
+  const timeout = getApiTimeout();
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const requestBody: { password?: string } = {};
+
+    if (data.password && data.password.trim() !== '') {
+      requestBody.password = data.password;
+    }
+
+    const response = await fetch(`${apiUrl}/api/v1/user/me/profile`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify(requestBody),
+      signal: controller.signal,
+      credentials: 'include',
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorData = (await response.json().catch(() => null)) as ApiErrorResponse | null;
+
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('[updateUserProfile] API 에러:', {
+          status: response.status,
+          statusText: response.statusText,
+          errorData,
+          url: `${apiUrl}/api/v1/user/me/profile`,
+        });
+      }
+
+      throw new Error(errorData?.message || `프로필 변경에 실패했습니다. (${response.status})`);
+    }
+  } catch (error) {
+    clearTimeout(timeoutId);
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error('요청 시간이 초과되었습니다.');
+    }
+    throw error;
+  }
+}

--- a/src/features/profile/schemas/profileSchema.ts
+++ b/src/features/profile/schemas/profileSchema.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+
+export const profileEditSchema = z
+  .object({
+    companyName: z.string().min(1, '기업명을 입력해주세요.'),
+    role: z.string(),
+    name: z.string(),
+    email: z.string().email(),
+    password: z
+      .string()
+      .optional()
+      .or(z.literal(''))
+      .refine(
+        (val) => {
+          // 비밀번호가 입력된 경우에만 길이 검증
+          if (!val || val === '') return true;
+          return val.length >= 8;
+        },
+        { message: '비밀번호는 최소 8자 이상이어야 합니다.' }
+      ),
+    passwordConfirm: z.string().optional().or(z.literal('')),
+  })
+  .refine((data) => !data.password || data.password === data.passwordConfirm, {
+    message: '비밀번호가 일치하지 않습니다.',
+    path: ['passwordConfirm'],
+  });
+
+export type ProfileEditInput = z.infer<typeof profileEditSchema>;

--- a/src/features/profile/schemas/profileSchema.ts
+++ b/src/features/profile/schemas/profileSchema.ts
@@ -3,8 +3,8 @@ import { z } from 'zod';
 export const profileEditSchema = z
   .object({
     companyName: z.string().min(1, '기업명을 입력해주세요.'),
-    role: z.string(),
-    name: z.string(),
+    role: z.string().min(1, '권한 정보가 필요합니다.'),
+    name: z.string().min(1, '이름을 입력해주세요.'),
     email: z.string().email(),
     password: z
       .string()

--- a/src/features/profile/section/ProfileEditSection.tsx
+++ b/src/features/profile/section/ProfileEditSection.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { profileEditSchema, type ProfileEditInput } from '@/features/profile/schemas/profileSchema';
+import { useAuthStore } from '@/lib/store/authStore';
+import { getCompany } from '@/features/profile/api/company.api';
+import { updateAdminProfile, updateUserProfile } from '@/features/profile/api/profile.api';
+import ProfileEditTemplate from '@/features/profile/template/ProfileEditTemplate';
+
+const getRoleDisplayName = (role?: string) => {
+  switch (role) {
+    case 'admin':
+      return '최고 관리자';
+    case 'manager':
+      return '관리자';
+    case 'user':
+      return '직원';
+    default:
+      return '직원';
+  }
+};
+
+const ProfileEditSection = () => {
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('');
+  const { user, accessToken } = useAuthStore();
+
+  const form = useForm<ProfileEditInput>({
+    resolver: zodResolver(profileEditSchema),
+    mode: 'onTouched',
+    defaultValues: {
+      companyName: '',
+      role: getRoleDisplayName(user?.role),
+      name: user?.name || '',
+      email: user?.email || '',
+      password: '',
+      passwordConfirm: '',
+    },
+  });
+
+  // 회사 정보 조회 (폼 초기값 설정)
+  useEffect(() => {
+    const fetchCompanyData = async () => {
+      if (!accessToken) return;
+
+      try {
+        const company = await getCompany(accessToken);
+        form.setValue('companyName', company.name);
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          // eslint-disable-next-line no-console
+          console.error('[ProfileEdit] 회사 정보 조회 실패:', error);
+        }
+        // 실패 시 기본값 사용
+        form.setValue('companyName', 'SNACK');
+      }
+    };
+
+    // eslint-disable-next-line no-void
+    void fetchCompanyData();
+  }, [accessToken, form]);
+
+  useEffect(() => {
+    if (showToast) {
+      const timer = setTimeout(() => setShowToast(false), 3000);
+      return () => clearTimeout(timer);
+    }
+    return undefined;
+  }, [showToast]);
+
+  const onSubmit = async (values: ProfileEditInput): Promise<void> => {
+    setServerError(null);
+
+    try {
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.log('[ProfileEdit] 프로필 수정:', values);
+      }
+
+      if (!user?.id || !user?.companyId || !accessToken) {
+        throw new Error('사용자 정보를 찾을 수 없습니다.');
+      }
+
+      // 사용자 역할에 따라 다른 API 엔드포인트 사용
+      const isAdmin = user.role === 'admin';
+
+      if (isAdmin) {
+        // ADMIN: 회사명 + 비밀번호 변경 가능
+        // 엔드포인트: PATCH /api/v1/user/admin/profile
+        const hasCompanyNameChange = values.companyName && values.companyName.trim() !== '';
+        const hasPasswordChange = values.password && values.password.trim() !== '';
+
+        if (!hasCompanyNameChange && !hasPasswordChange) {
+          throw new Error('변경할 내용을 입력해주세요.');
+        }
+
+        await updateAdminProfile(
+          {
+            companyName: hasCompanyNameChange ? values.companyName : undefined,
+            password: hasPasswordChange ? values.password : undefined,
+          },
+          accessToken
+        );
+      } else {
+        // USER, MANAGER: 비밀번호만 변경 가능
+        // 엔드포인트: PATCH /api/v1/user/me/profile
+        const hasPasswordChange = values.password && values.password.trim() !== '';
+
+        if (!hasPasswordChange) {
+          throw new Error('변경할 내용을 입력해주세요.');
+        }
+
+        await updateUserProfile(
+          {
+            password: values.password,
+          },
+          accessToken
+        );
+      }
+
+      setToastMessage('프로필이 성공적으로 변경되었습니다.');
+      setShowToast(true);
+
+      form.reset({
+        ...values,
+        password: '',
+        passwordConfirm: '',
+      });
+    } catch (error) {
+      if (process.env.NODE_ENV === 'development') {
+        // eslint-disable-next-line no-console
+        console.error('[ProfileEdit] 프로필 수정 실패:', error);
+      }
+      const errorMessage = error instanceof Error ? error.message : '프로필 변경에 실패했습니다.';
+      setToastMessage(errorMessage);
+      setShowToast(true);
+      setServerError(errorMessage);
+    }
+  };
+
+  return (
+    <ProfileEditTemplate
+      control={form.control}
+      handleSubmit={form.handleSubmit}
+      isValid={form.formState.isValid}
+      serverError={serverError}
+      onSubmit={onSubmit}
+      showToast={showToast}
+      toastMessage={toastMessage}
+      setShowToast={setShowToast}
+      isAdmin={user?.role === 'admin'}
+    />
+  );
+};
+
+export default ProfileEditSection;

--- a/src/features/profile/section/ProfileEditSection.tsx
+++ b/src/features/profile/section/ProfileEditSection.tsx
@@ -61,7 +61,7 @@ const ProfileEditSection = () => {
 
     // eslint-disable-next-line no-void
     void fetchCompanyData();
-  }, [accessToken, form]);
+  }, [accessToken]); // form.setValue는 안정적인 참조를 가짐
 
   useEffect(() => {
     if (showToast) {

--- a/src/features/profile/section/ProfileEditSection.tsx
+++ b/src/features/profile/section/ProfileEditSection.tsx
@@ -54,8 +54,8 @@ const ProfileEditSection = () => {
           // eslint-disable-next-line no-console
           console.error('[ProfileEdit] 회사 정보 조회 실패:', error);
         }
-        // 실패 시 기본값 사용
-        form.setValue('companyName', 'SNACK');
+        // 실패 시 빈 값으로 설정하여 사용자가 직접 입력하도록 유도
+        form.setValue('companyName', '');
       }
     };
 

--- a/src/features/profile/template/ProfileEditTemplate.tsx
+++ b/src/features/profile/template/ProfileEditTemplate.tsx
@@ -88,6 +88,7 @@ const ProfileEditTemplate = ({
   control,
   handleSubmit,
   isValid,
+  serverError,
   onSubmit,
   showToast,
   toastMessage,
@@ -97,6 +98,11 @@ const ProfileEditTemplate = ({
   <>
     {/* Mobile Layout */}
     <div className="flex flex-col px-24 py-45 tablet:hidden desktop:hidden">
+      {serverError && (
+        <div className="mb-20 p-16 bg-red-50 border border-red-200 rounded-default text-red-600 text-14">
+          {serverError}
+        </div>
+      )}
       <ProfileEditForm
         control={control}
         isValid={isValid}
@@ -110,6 +116,11 @@ const ProfileEditTemplate = ({
     {/* Tablet & Desktop Layout */}
     <div className="hidden tablet:flex desktop:flex flex-col items-center pt-171 pb-261">
       <div className="w-600 bg-white rounded-default shadow-[0px_0px_40px_0px_rgba(0,0,0,0.1)] px-60 py-40">
+        {serverError && (
+          <div className="mb-20 p-16 bg-red-50 border border-red-200 rounded-default text-red-600 text-14">
+            {serverError}
+          </div>
+        )}
         <ProfileEditForm
           control={control}
           isValid={isValid}

--- a/src/features/profile/template/ProfileEditTemplate.tsx
+++ b/src/features/profile/template/ProfileEditTemplate.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { type Control, type UseFormHandleSubmit } from 'react-hook-form';
+import RHFFloatingLabelInput from '@/components/molecules/RHFFloatingLabelInput/RHFFloatingLabelInput';
+import Button from '@/components/atoms/Button/Button';
+import type { ProfileEditInput } from '@/features/profile/schemas/profileSchema';
+import { Toast } from '@/components/molecules/Toast/Toast';
+
+/**
+ * 프로필 수정 템플릿 Props
+ */
+interface ProfileEditTemplateProps {
+  control: Control<ProfileEditInput>;
+  handleSubmit: UseFormHandleSubmit<ProfileEditInput>;
+  isValid: boolean;
+  // eslint-disable-next-line react/no-unused-prop-types
+  serverError: string | null;
+  onSubmit: (values: ProfileEditInput) => void | Promise<void>;
+  showToast: boolean;
+  toastMessage: string;
+  setShowToast: (show: boolean) => void;
+  /** 관리자 여부 - true일 경우 기업명 필드 표시 */
+  isAdmin: boolean;
+}
+
+/**
+ * 프로필 수정 폼 Props
+ */
+interface ProfileEditFormProps {
+  control: Control<ProfileEditInput>;
+  handleSubmit: UseFormHandleSubmit<ProfileEditInput>;
+  isValid: boolean;
+  onSubmit: (values: ProfileEditInput) => void | Promise<void>;
+  className?: string;
+  /** 관리자 여부 - true일 경우 기업명 필드 표시 */
+  isAdmin: boolean;
+}
+
+const ProfileEditForm = ({
+  control,
+  isValid,
+  onSubmit,
+  handleSubmit,
+  className,
+  isAdmin,
+}: ProfileEditFormProps) => (
+  <form
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
+    onSubmit={handleSubmit(onSubmit)}
+    className={className}
+    noValidate
+  >
+    <h1 className="text-24 font-bold text-black-400 tracking--0.6 text-center mb-20">
+      내 프로필 변경
+    </h1>
+
+    <div className="flex flex-col gap-20">
+      {/* 관리자만 기업명 변경 가능 */}
+      {isAdmin && (
+        <RHFFloatingLabelInput control={control} name="companyName" label="기업명" type="text" />
+      )}
+      <RHFFloatingLabelInput control={control} name="role" label="권한" type="text" disabled />
+      <RHFFloatingLabelInput control={control} name="name" label="이름" type="text" disabled />
+      <RHFFloatingLabelInput control={control} name="email" label="이메일" type="email" disabled />
+      <RHFFloatingLabelInput
+        control={control}
+        name="password"
+        label="비밀번호를 입력해주세요"
+        type="password"
+        showPasswordToggle
+      />
+      <RHFFloatingLabelInput
+        control={control}
+        name="passwordConfirm"
+        label="비밀번호를 한번 더 입력해주세요"
+        type="password"
+        showPasswordToggle
+      />
+    </div>
+
+    <Button type="submit" size="lg" className="mt-30" fullWidth inactive={!isValid}>
+      변경하기
+    </Button>
+  </form>
+);
+
+const ProfileEditTemplate = ({
+  control,
+  handleSubmit,
+  isValid,
+  onSubmit,
+  showToast,
+  toastMessage,
+  setShowToast,
+  isAdmin,
+}: ProfileEditTemplateProps) => (
+  <>
+    {/* Mobile Layout */}
+    <div className="flex flex-col px-24 py-45 tablet:hidden desktop:hidden">
+      <ProfileEditForm
+        control={control}
+        isValid={isValid}
+        onSubmit={onSubmit}
+        handleSubmit={handleSubmit}
+        className="flex flex-col w-full"
+        isAdmin={isAdmin}
+      />
+    </div>
+
+    {/* Tablet & Desktop Layout */}
+    <div className="hidden tablet:flex desktop:flex flex-col items-center pt-171 pb-261">
+      <div className="w-600 bg-white rounded-default shadow-[0px_0px_40px_0px_rgba(0,0,0,0.1)] px-60 py-40">
+        <ProfileEditForm
+          control={control}
+          isValid={isValid}
+          onSubmit={onSubmit}
+          handleSubmit={handleSubmit}
+          className="flex flex-col w-480"
+          isAdmin={isAdmin}
+        />
+      </div>
+    </div>
+
+    {/* Toast */}
+    {showToast && (
+      <div className="fixed top-20 left-1/2 transform -translate-x-1/2 z-toast">
+        <Toast variant="custom" message={toastMessage} onClose={() => setShowToast(false)} />
+      </div>
+    )}
+  </>
+);
+
+export default ProfileEditTemplate;

--- a/src/lib/store/authStore.ts
+++ b/src/lib/store/authStore.ts
@@ -7,6 +7,7 @@ import type { UserRole } from '@/constants/roles';
 export interface User {
   id: string;
   email: string;
+  name: string;
   role: UserRole;
   companyId: string;
 }


### PR DESCRIPTION
## 📝 변경사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->

- 프로필 페이지 및 프로필 카드를 생성하였습니다.

## 🔨 작업 내용

- [x] 프로필 페이지 생성
- [x] GNB에 프로필 카드 생성
- [x] 백엔드 API 연동

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->

1. 프로필 페이지가 잘 실행되는지 확인합니다.
2. 그 다음, 회사 이름을 수정합니다.
3. Swagger 문서의 company API를 통해 회사이름이 변경되었는지 확인합니다.

## 📸 스크린샷 (UI 변경 시)

<!-- UI 변경이 있다면 Before/After 스크린샷을 첨부해주세요 -->

<img width="3813" height="1903" alt="image" src="https://github.com/user-attachments/assets/2446b22b-4d2f-4631-9781-228959a0c510" />

## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [ ] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #105 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자 프로필 편집 기능 추가(관리자: 회사명·비밀번호, 일반: 비밀번호)
  * 프로필 편집 화면 및 템플릿, 폼(react-hook-form·Zod) 연동 추가
  * 플로팅 라벨 입력 및 RHF 통합 입력 컴포넌트 추가(비밀번호 가시성 토글 등)
  * 아바타에 사용자 이름 이니셜 표시 지원
  * 회사 정보 조회 API 및 GNB에 회사명 노출
* **업데이트**
  * 사용자 모델 및 인증 응답에 name 필드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->