### PR TITLE
fix: allow custom approval messages for purchase requests

### DIFF
--- a/src/features/purchase-history/section/PurchaseHistoryDetailSection.tsx
+++ b/src/features/purchase-history/section/PurchaseHistoryDetailSection.tsx
@@ -76,14 +76,19 @@ const PurchaseHistoryDetailSection = ({ orderId }: PurchaseHistoryDetailSectionP
 
   // 승인 정보 변환
   const { status } = purchaseDetail;
+
+  let resultMessage: string;
+  if (status === 'APPROVED') {
+    resultMessage = purchaseDetail.reason || PURCHASE_HISTORY_MESSAGES.RESULT.APPROVED;
+  } else {
+    resultMessage = purchaseDetail.rejectReason || '';
+  }
+
   const approvedInfo = {
     approverName: purchaseDetail.approver?.name || '관리자',
     approvalDate: purchaseDetail.updatedAt,
     statusLabel: PURCHASE_REQUEST_STATUS_LABEL[status],
-    resultMessage:
-      status === 'APPROVED'
-        ? PURCHASE_HISTORY_MESSAGES.RESULT.APPROVED
-        : purchaseDetail.rejectReason || '',
+    resultMessage,
   };
 
   return (

--- a/src/features/purchase/api/purchase.admin.api.ts
+++ b/src/features/purchase/api/purchase.admin.api.ts
@@ -202,18 +202,28 @@ export async function getPurchaseRequestDetail(
 }
 
 /**
+ * 구매 요청 승인 (관리자)
+ */
+export interface ApprovePurchaseRequestRequest {
+  message?: string;
+}
+
+/**
  * 관리자 권한으로 지정된 구매 요청을 승인합니다.
  *
  * @param purchaseRequestId - 승인할 구매 요청의 식별자
+ * @param request - 승인 메시지를 포함한 요청 본문 (선택적)
  * @returns 승인된 구매 요청의 상세 정보를 담은 `PurchaseRequestItem`
  */
 export async function approvePurchaseRequest(
-  purchaseRequestId: string
+  purchaseRequestId: string,
+  request?: ApprovePurchaseRequestRequest
 ): Promise<PurchaseRequestItem> {
   const result = await fetchWithAuth<PurchaseRequestItem>(
     `${PURCHASE_API_PATHS.ADMIN_APPROVE_PURCHASE_REQUEST}/${purchaseRequestId}`,
     {
       method: 'PATCH',
+      body: request ? JSON.stringify(request) : undefined,
     }
   );
 

--- a/src/features/purchase/api/purchase.types.ts
+++ b/src/features/purchase/api/purchase.types.ts
@@ -31,6 +31,7 @@ export interface PurchaseRequestItem {
   status: 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELLED';
   requestMessage?: string;
   rejectReason?: string;
+  reason?: string; // 승인 사유
   urgent?: boolean;
   purchaseItems: Array<{
     id: string;

--- a/src/features/purchase/handlers/usePurchaseModalHandlers.ts
+++ b/src/features/purchase/handlers/usePurchaseModalHandlers.ts
@@ -71,10 +71,10 @@ export const usePurchaseModalHandlers = ({
   );
 
   const handleApproveSubmit = useCallback(
-    (_message: string) => {
+    (message: string) => {
       if (!selectedRequestId) return;
       approveMutation.mutate(
-        { purchaseRequestId: selectedRequestId, companyId },
+        { purchaseRequestId: selectedRequestId, message, companyId },
         {
           onSuccess: () => {
             // 캐시 즉시 제거하여 최신 데이터 보장

--- a/src/features/purchase/queries/purchase.queries.ts
+++ b/src/features/purchase/queries/purchase.queries.ts
@@ -220,26 +220,29 @@ export function useApprovePurchaseRequest() {
   const queryClient = useQueryClient();
   const { triggerToast } = useToast();
 
-  return useMutation<PurchaseRequestItem, Error, { purchaseRequestId: string; companyId?: string }>(
-    {
-      mutationFn: async ({ purchaseRequestId }) => approvePurchaseRequest(purchaseRequestId),
-      onSuccess: async (_, variables) => {
-        const { purchaseRequestId, companyId } = variables;
+  return useMutation<
+    PurchaseRequestItem,
+    Error,
+    { purchaseRequestId: string; message?: string; companyId?: string }
+  >({
+    mutationFn: async ({ purchaseRequestId, message }) =>
+      approvePurchaseRequest(purchaseRequestId, message ? { message } : undefined),
+    onSuccess: async (_, variables) => {
+      const { purchaseRequestId, companyId } = variables;
 
-        // 관련 쿼리 캐시 무효화
-        await queryClient.invalidateQueries({ queryKey: purchaseKeys.detail(purchaseRequestId) });
-        await queryClient.invalidateQueries({ queryKey: purchaseKeys.all });
-        if (companyId) {
-          await queryClient.invalidateQueries({ queryKey: purchaseKeys.budget(companyId) });
-        }
-      },
-      onError: (err: unknown) => {
-        const message = err instanceof Error ? err.message : '구매 요청 승인에 실패했습니다.';
-        triggerToast('error', message);
-        logger.error('구매 요청 승인 실패:', err);
-      },
-    }
-  );
+      // 관련 쿼리 캐시 무효화
+      await queryClient.invalidateQueries({ queryKey: purchaseKeys.detail(purchaseRequestId) });
+      await queryClient.invalidateQueries({ queryKey: purchaseKeys.all });
+      if (companyId) {
+        await queryClient.invalidateQueries({ queryKey: purchaseKeys.budget(companyId) });
+      }
+    },
+    onError: (err: unknown) => {
+      const message = err instanceof Error ? err.message : '구매 요청 승인에 실패했습니다.';
+      triggerToast('error', message);
+      logger.error('구매 요청 승인 실패:', err);
+    },
+  });
 }
 
 /**

--- a/src/features/purchase/template/MyPurchaseRequestDetailTem/MyPurchaseRequestDetailTem.tsx
+++ b/src/features/purchase/template/MyPurchaseRequestDetailTem/MyPurchaseRequestDetailTem.tsx
@@ -31,7 +31,8 @@ const MyPurchaseRequestDetailTem = ({
   if (purchaseRequest.status === 'REJECTED' && purchaseRequest.rejectReason) {
     resultMessage = purchaseRequest.rejectReason;
   } else if (purchaseRequest.status === 'APPROVED') {
-    resultMessage = PURCHASE_RESULT_MESSAGES.APPROVED;
+    // reason이 있으면 사용, 없으면 기본 메시지
+    resultMessage = purchaseRequest.reason || PURCHASE_RESULT_MESSAGES.APPROVED;
   }
 
   const approvedInfo = {

--- a/src/features/purchase/template/PurchaseRequestDetailTem/PurchaseRequestDetailTem.tsx
+++ b/src/features/purchase/template/PurchaseRequestDetailTem/PurchaseRequestDetailTem.tsx
@@ -50,6 +50,36 @@ const PurchaseRequestDetailTem = ({
         purchaseRequest.shippingFee),
   };
 
+  // ApprovedInfo 생성 (승인/반려된 경우만)
+  let approvedInfo:
+    | {
+        approverName: string;
+        approvalDate: string | null;
+        statusLabel: string;
+        resultMessage: string;
+      }
+    | undefined;
+
+  if (purchaseRequest.status === 'APPROVED' || purchaseRequest.status === 'REJECTED') {
+    let statusLabel = '-';
+    if (purchaseRequest.status === 'APPROVED') {
+      statusLabel = '승인';
+    } else if (purchaseRequest.status === 'REJECTED') {
+      statusLabel = '반려';
+    }
+
+    const reasonMessage = purchaseRequest.reason || '';
+    const rejectMessage = purchaseRequest.rejectReason || '';
+    const resultMessage = reasonMessage || rejectMessage || '-';
+
+    approvedInfo = {
+      approverName: purchaseRequest.approver?.name || '-',
+      approvalDate: purchaseRequest.approvedAt || null,
+      statusLabel,
+      resultMessage,
+    };
+  }
+
   // 모달 데이터 변환
   const modalData = {
     user: {
@@ -94,7 +124,11 @@ const PurchaseRequestDetailTem = ({
       <div className="flex flex-col items-center gap-30 mt-30">
         <div className="tablet:mt-30 desktop:mt-60 mb-54 desktop:mb-254 tablet:mb-132">
           <PurchaseRequestDetailTopOrg purchaseRequest={purchaseRequest} />
-          <PurchaseRequestDetailOrg purchaseRequest={purchaseRequest} budgetInfo={budgetInfo} />
+          <PurchaseRequestDetailOrg
+            purchaseRequest={purchaseRequest}
+            budgetInfo={budgetInfo}
+            approvedInfo={approvedInfo}
+          />
           <PurchaseRequestDetailActionsOrg
             companyId={companyId}
             actionType="admin"


### PR DESCRIPTION
## 📝 변경사항

<!-- 무엇을 변경했는지 간단히 설명해주세요 -->

구매 승인 메시지를 입력하거나 출력하는 문제를 해결

## 🔨 작업 내용

- [x] 승인할 경우에 승인 메시지를 백엔드에 전달
- [x] 승인 메시지를 결과 창에 출력

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 설명해주세요 -->

1. 화면에 나타나는지 확인

## 📸 스크린샷 (UI 변경 시)

<img width="1815" height="1139" alt="image" src="https://github.com/user-attachments/assets/ad000361-bb15-4e26-b250-8e316762554c" />

## ✅ 체크리스트

- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈

Closes #156 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 구매 요청 승인 시 선택적 메시지(사유)를 함께 전송 가능
  * 승인/반려 상세 정보에 승인자명·승인일·상태 레이블·결과 메시지(사유 포함) 표시
  * 기존 승인 메시지 우선순위: 요청의 사유가 있으면 이를 우선 표시하도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->