### PR TITLE
refactor: Replace img with next image component (#125)

### DIFF
--- a/src/features/products/template/ProductListTem/components/ProductListHeader.tsx
+++ b/src/features/products/template/ProductListTem/components/ProductListHeader.tsx
@@ -4,6 +4,7 @@ import { clsx } from '@/utils/clsx';
 import Breadcrumb, { type BreadcrumbItem } from '@/components/molecules/Breadcrumb/Breadcrumb';
 import DropDown, { type Option } from '@/components/atoms/DropDown/DropDown';
 import { PRODUCT_LIST_STYLES } from '@/features/products/utils/constants';
+import Image from 'next/image';
 
 interface ProductListHeaderProps {
   breadcrumbItems: BreadcrumbItem[];
@@ -49,7 +50,7 @@ export const ProductListHeader = ({
             onSelect={onChangeSort}
           />
           <button type="button" className={buttonClass} onClick={onOpenModal}>
-            <img src="/icons/plus-white.svg" alt="" aria-hidden className="w-16 h-16" />
+            <Image src="/icons/plus-white.svg" alt="" aria-hidden width={16} height={16} />
             <span>상품 등록</span>
           </button>
         </div>
@@ -69,7 +70,7 @@ export const ProductListHeader = ({
             onSelect={onChangeSort}
           />
           <button type="button" className={buttonClass} onClick={onOpenModal}>
-            <img src="/icons/plus-white.svg" alt="" aria-hidden className="w-16 h-16" />
+            <Image src="/icons/plus-white.svg" alt="" aria-hidden width={16} height={16} />
             <span>상품 등록</span>
           </button>
         </div>


### PR DESCRIPTION
## 📝 변경사항
상품 목록 헤더 컴포넌트에서 사용하던 img 태그를
next/image 컴포넌트로 변경했습니다.

## 🔨 작업 내용
- [x] ProductListHeader 내 img 태그 제거
- [x] next/image Image 컴포넌트 적용
- [x] 아이콘 이미지 렌더링 방식 통일

## 🧪 테스트 방법
1. 상품 목록 페이지 진입
2. 데스크탑 / 모바일 화면에서 헤더 영역 확인
3. 상품 등록 버튼 아이콘 정상 렌더링 여부 확인

## 📸 스크린샷 (UI 변경 시)
<!-- UI 변경은 있으나 시각적 차이는 거의 없어 스크린샷은 생략합니다 -->

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * 이미지 로딩 성능을 개선했습니다. 제품 목록 페이지의 이미지 처리 효율을 최적화하여 더 빠른 로딩 속도를 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->