### PR TITLE
style: Update CartButton badge to match NotificationButton (#125)

### DIFF
--- a/src/components/molecules/CartButton/CartButton.tsx
+++ b/src/components/molecules/CartButton/CartButton.tsx
@@ -12,8 +12,7 @@ import type { CartButtonProps } from './CartButtonProps';
  * CartButton
  *
  * - 장바구니 아이콘 + 숫자 뱃지 Molecule
- * - 뷰포트 상관 없이(모바일/태블릿/데스크탑) 항상 노출
- * - 숫자 폰트: 9px, text-gray-950
+ * - NotificationButton과 동일한 숫자 뱃지 UI
  * - 아이콘 크기: 24px
  */
 export const CartButton = ({
@@ -63,19 +62,21 @@ export const CartButton = ({
           aria-hidden="true"
         />
 
-        {/* 숫자 뱃지: count가 0보다 클 때만 표시 */}
+        {/* 숫자 뱃지: NotificationButton과 동일 */}
         {displayCount > 0 && (
           <span
             className={clsx(
               'pointer-events-none',
               'absolute',
-              'top-9 left-5',
-              'min-w-14 h-14',
+              '-top-4 -right-6',
+              'min-w-16 h-16 px-4',
               'flex justify-center items-center',
-              'text-11 font-bold text-gray-950'
+              'bg-gray-200 text-black',
+              'text-10 font-bold',
+              'rounded-full'
             )}
           >
-            {displayCount > 99 ? '99' : displayCount}
+            {displayCount > 99 ? '99+' : displayCount}
           </span>
         )}
       </div>


### PR DESCRIPTION
## 📝 변경사항
CartButton의 숫자 뱃지 UI를 NotificationButton과 동일하게 수정했습니다.
아이콘 크기는 24px로 유지하면서, 뱃지 위치, 크기, 스타일을 정리했습니다.

## 🔨 작업 내용
- [x] 숫자 뱃지 위치 및 크기를 NotificationButton과 동일하게 조정
- [x] 99 이상일 경우 '99+' 표시
- [x] 뱃지 배경, 텍스트 색상, 폰트, border-radius 적용
- [x] 아이콘 크기 24px 유지

## 🧪 테스트 방법
1. CartButton이 표시되는 화면에서 아이콘과 뱃지 확인
2. count가 0일 때 뱃지가 숨겨지는지 확인
3. count가 99 이상일 때 '99+'로 표시되는지 확인
4. 클릭 시 아이콘 애니메이션 정상 동작 확인

## 📸 스크린샷 (UI 변경 시)

| Before | After |
|--------|-------|
<img width="54" height="49" alt="image" src="https://github.com/user-attachments/assets/9893c007-a326-4393-8e13-964951b84897" />


## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 장바구니 버튼의 알림 배지 위치와 크기를 조정했습니다.
  * 배지의 색상과 텍스트 크기를 개선했습니다.
  * 99개 이상의 항목은 '99+'로 표시하도록 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->