### PR TITLE
feat: implement excel reporting

### DIFF
--- a/src/features/dashboard/api/report.api.ts
+++ b/src/features/dashboard/api/report.api.ts
@@ -1,0 +1,72 @@
+'use client';
+
+import { fetchWithAuth } from '@/utils/api';
+
+// 구매 요청 승인/거절 리포트 엑셀 다운로드
+export const REPORT_API_PATHS = {
+  EXPORT_PURCHASE_REQUESTS: '/api/v1/report/admin/exportPurchaseRequests',
+} as const;
+
+// 구매 요청 엑셀 내보내기 파라미터
+export interface ExportPurchaseRequestsParams {
+  /** 결정 시작 일시 (ISO 8601) */
+  from: string;
+  /** 결정 종료 일시 (ISO 8601) */
+  to: string;
+  /** 결정 상태 필터 (선택) */
+  status?: 'APPROVED' | 'REJECTED';
+  /** 요청자 역할 필터 (선택) */
+  role?: 'USER' | 'MANAGER' | 'ADMIN' | 'ALL';
+}
+
+/**
+ * 구매 요청 승인/거절 리포트 엑셀 다운로드 (관리자)
+ * GET /api/v1/report/admin/exportPurchaseRequests
+ *
+ * @param params 필터 파라미터
+ * @returns Blob (엑셀 파일)
+ */
+export const exportPurchaseRequests = async (
+  params: ExportPurchaseRequestsParams
+): Promise<Blob> => {
+  const searchParams = new URLSearchParams({
+    from: params.from,
+    to: params.to,
+  });
+
+  if (params.status) {
+    searchParams.append('status', params.status);
+  }
+  if (params.role) {
+    searchParams.append('role', params.role);
+  }
+
+  const url = `${REPORT_API_PATHS.EXPORT_PURCHASE_REQUESTS}?${searchParams.toString()}`;
+
+  const response = await fetchWithAuth(url, {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    const errorData = (await response.json().catch(() => ({}))) as { message?: string };
+    throw new Error(errorData.message || '엑셀 다운로드에 실패했습니다.');
+  }
+
+  return response.blob();
+};
+
+/**
+ * Blob을 파일로 다운로드
+ * @param blob 다운로드할 Blob
+ * @param filename 저장할 파일명
+ */
+export const downloadBlob = (blob: Blob, filename: string): void => {
+  const url = window.URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+};

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.stories.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.stories.tsx
@@ -1,0 +1,62 @@
+/* eslint-disable */
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { ExcelExportModal } from './ExcelExportModal';
+
+const meta: Meta<typeof ExcelExportModal> = {
+  title: 'Features/Dashboard/Template/ExcelExportModal',
+  component: ExcelExportModal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `
+관리자용 **구매 요청 승인/거절 리포트 엑셀 다운로드 모달**입니다.
+
+## 기능
+
+- **날짜 범위 선택**: 시작일, 종료일 (필수)
+- **상태 필터**: 전체 / 승인 / 거절
+- **역할 필터**: 전체 / 일반 사용자 / 매니저 / 관리자
+
+## 동작
+
+- 날짜 미입력 시 다운로드 버튼 비활성화
+- 종료일이 시작일보다 이전인 경우 에러 메시지 표시
+- ESC 키로 모달 닫기 가능
+        `,
+      },
+    },
+  },
+  args: {
+    onClose: () => console.log('닫기 버튼'),
+    onExport: (data) => console.log('내보내기 버튼', data),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExcelExportModal>;
+
+/** 기본 상태 (모달 열림) */
+export const Default: Story = {
+  args: {
+    open: true,
+    isLoading: false,
+  },
+};
+
+/** 로딩 상태 */
+export const Loading: Story = {
+  args: {
+    open: true,
+    isLoading: true,
+  },
+};
+
+/** 모달 닫힘 */
+export const Closed: Story = {
+  args: {
+    open: false,
+    isLoading: false,
+  },
+};

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -88,10 +88,10 @@ export const ExcelExportModal = ({
   const handleExport = () => {
     if (!isValid || isLoading) return;
 
-    // date(YYYY-MM-DD) -> ISO 8601 변환 (시작일: 00:00:00, 종료일: 23:59:59)
+    // date(YYYY-MM-DD) -> ISO 8601 변환 (날짜만)
     const params: ExcelExportParams = {
-      from: new Date(`${fromDate}T00:00:00`).toISOString(),
-      to: new Date(`${toDate}T23:59:59`).toISOString(),
+      from: fromDate,
+      to: toDate,
     };
 
     if (status) {

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -41,14 +41,14 @@ const getLocalDateString = (date: Date): string => {
   return `${year}-${month}-${day}`;
 };
 
-// 기본 시작일: 이번 달 1일 00:00
+// 기본 시작일: 이번 달 1일
 const getDefaultFromDate = (): string => {
   const now = new Date();
   const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
   return getLocalDateString(firstDay);
 };
 
-// 기본 종료일: 현재 시간
+// 기본 종료일: 현재 날짜
 const getDefaultToDate = (): string => getLocalDateString(new Date());
 
 export const ExcelExportModal = ({

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -25,7 +25,7 @@ const STATUS_OPTIONS = [
 ] as const;
 
 const ROLE_OPTIONS = [
-  { value: '', label: '전체' },
+  { value: 'ALL', label: '전체' },
   { value: 'USER', label: '일반 사용자' },
   { value: 'MANAGER', label: '매니저' },
   { value: 'ADMIN', label: '관리자' },

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -119,11 +119,15 @@ export const ExcelExportModal = ({
       className="fixed inset-0 z-[var(--z-overlay-content)] flex items-center justify-center bg-black/50 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
+      aria-labelledby="excel-export-title"
+      aria-describedby="excel-export-desc"
     >
       <div className="bg-white rounded-16 p-24 w-full max-w-400 shadow-xl m-16">
-        <h2 className="text-18 font-bold text-gray-900 mb-16">엑셀 리포트 다운로드</h2>
+        <h2 id="excel-export-title" className="text-18 font-bold text-gray-900 mb-16">
+          엑셀 리포트 다운로드
+        </h2>
 
-        <p className="text-14 text-gray-600 mb-20">
+        <p id="excel-export-desc" className="text-14 text-gray-600 mb-20">
           구매 요청 승인/거절 내역을 엑셀 파일로 다운로드합니다.
         </p>
 

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -218,7 +218,7 @@ export const ExcelExportModal = ({
           </Button>
           <Button
             variant="primary"
-            className="w-100 h-40 text-14"
+            className="w-120 h-40 text-14 whitespace-nowrap"
             onClick={handleExport}
             inactive={!isValid || isLoading}
           >

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { clsx } from '@/utils/clsx';
+import Button from '@/components/atoms/Button/Button';
+
+export interface ExcelExportParams {
+  from: string;
+  to: string;
+  status?: 'APPROVED' | 'REJECTED';
+  role?: 'USER' | 'MANAGER' | 'ADMIN' | 'ALL';
+}
+
+interface ExcelExportModalProps {
+  open: boolean;
+  onClose: () => void;
+  onExport: (params: ExcelExportParams) => void | Promise<void>;
+  isLoading?: boolean;
+}
+
+const STATUS_OPTIONS = [
+  { value: '', label: '전체' },
+  { value: 'APPROVED', label: '승인' },
+  { value: 'REJECTED', label: '거절' },
+] as const;
+
+const ROLE_OPTIONS = [
+  { value: '', label: '전체' },
+  { value: 'USER', label: '일반 사용자' },
+  { value: 'MANAGER', label: '매니저' },
+  { value: 'ADMIN', label: '관리자' },
+] as const;
+
+/**
+ * date input 포맷에 맞는 날짜 문자열 반환 (YYYY-MM-DD)
+ */
+const getLocalDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+// 기본 시작일: 이번 달 1일 00:00
+const getDefaultFromDate = (): string => {
+  const now = new Date();
+  const firstDay = new Date(now.getFullYear(), now.getMonth(), 1);
+  return getLocalDateString(firstDay);
+};
+
+// 기본 종료일: 현재 시간
+const getDefaultToDate = (): string => getLocalDateString(new Date());
+
+export const ExcelExportModal = ({
+  open,
+  onClose,
+  onExport,
+  isLoading = false,
+}: ExcelExportModalProps) => {
+  const [fromDate, setFromDate] = useState(getDefaultFromDate);
+  const [toDate, setToDate] = useState(getDefaultToDate);
+  const [status, setStatus] = useState('');
+  const [role, setRole] = useState('');
+
+  // 모달이 열릴 때 날짜 초기화
+  useEffect(() => {
+    if (open) {
+      setFromDate(getDefaultFromDate());
+      setToDate(getDefaultToDate());
+      setStatus('');
+      setRole('');
+    }
+  }, [open]);
+
+  // ESC 키로 모달 닫기
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !isLoading) onClose();
+    };
+    if (open) window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [open, onClose, isLoading]);
+
+  if (!open) return null;
+
+  const isValid = fromDate && toDate && new Date(fromDate) <= new Date(toDate);
+
+  const handleExport = () => {
+    if (!isValid || isLoading) return;
+
+    // date(YYYY-MM-DD) -> ISO 8601 변환 (시작일: 00:00:00, 종료일: 23:59:59)
+    const params: ExcelExportParams = {
+      from: new Date(`${fromDate}T00:00:00`).toISOString(),
+      to: new Date(`${toDate}T23:59:59`).toISOString(),
+    };
+
+    if (status) {
+      params.status = status as 'APPROVED' | 'REJECTED';
+    }
+    if (role) {
+      params.role = role as 'USER' | 'MANAGER' | 'ADMIN' | 'ALL';
+    }
+
+    Promise.resolve(onExport(params)).catch(() => undefined);
+  };
+
+  const inputClassName = clsx(
+    'w-full h-44 px-12',
+    'border border-gray-200 rounded-8',
+    'text-14 text-gray-900',
+    'focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary',
+    'disabled:bg-gray-50 disabled:cursor-not-allowed'
+  );
+
+  const labelClassName = 'block text-14 font-medium text-gray-700 mb-6';
+
+  return (
+    <div
+      className="fixed inset-0 z-[var(--z-overlay-content)] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div className="bg-white rounded-16 p-24 w-full max-w-400 shadow-xl m-16">
+        <h2 className="text-18 font-bold text-gray-900 mb-16">엑셀 리포트 다운로드</h2>
+
+        <p className="text-14 text-gray-600 mb-20">
+          구매 요청 승인/거절 내역을 엑셀 파일로 다운로드합니다.
+        </p>
+
+        {/* 날짜 입력 */}
+        {/* eslint-disable jsx-a11y/label-has-associated-control */}
+        <div className="space-y-16 mb-20">
+          {/* 시작일 */}
+          <div>
+            <label htmlFor="excel-from-date" className={labelClassName}>
+              시작일 <span className="text-error-500">*</span>
+            </label>
+            <input
+              id="excel-from-date"
+              type="date"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+              className={inputClassName}
+              disabled={isLoading}
+            />
+          </div>
+
+          {/* 종료일 */}
+          <div>
+            <label htmlFor="excel-to-date" className={labelClassName}>
+              종료일 <span className="text-error-500">*</span>
+            </label>
+            <input
+              id="excel-to-date"
+              type="date"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+              className={inputClassName}
+              disabled={isLoading}
+            />
+          </div>
+
+          {/* 상태 필터 */}
+          <div>
+            <label htmlFor="excel-status" className={labelClassName}>
+              결정 상태
+            </label>
+            <select
+              id="excel-status"
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className={inputClassName}
+              disabled={isLoading}
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 역할 필터 */}
+          <div>
+            <label htmlFor="excel-role" className={labelClassName}>
+              요청자 역할
+            </label>
+            <select
+              id="excel-role"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className={inputClassName}
+              disabled={isLoading}
+            >
+              {ROLE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {/* 날짜 유효성 에러 */}
+        {fromDate && toDate && new Date(fromDate) > new Date(toDate) && (
+          <p className="text-12 text-error-500 mb-12">종료일은 시작일 이후여야 합니다.</p>
+        )}
+
+        {/* 버튼 */}
+        <div className="flex justify-end gap-10">
+          <Button
+            variant="secondary"
+            className="w-80 h-40 text-14"
+            onClick={onClose}
+            inactive={isLoading}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            className="w-100 h-40 text-14"
+            onClick={handleExport}
+            inactive={!isValid || isLoading}
+          >
+            {isLoading ? '다운로드 중...' : '다운로드'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
+++ b/src/features/dashboard/template/DashboardTem/ExcelExportModal.tsx
@@ -60,7 +60,7 @@ export const ExcelExportModal = ({
   const [fromDate, setFromDate] = useState(getDefaultFromDate);
   const [toDate, setToDate] = useState(getDefaultToDate);
   const [status, setStatus] = useState('');
-  const [role, setRole] = useState('');
+  const [role, setRole] = useState('ALL');
 
   // 모달이 열릴 때 날짜 초기화
   useEffect(() => {
@@ -68,7 +68,7 @@ export const ExcelExportModal = ({
       setFromDate(getDefaultFromDate());
       setToDate(getDefaultToDate());
       setStatus('');
-      setRole('');
+      setRole('ALL');
     }
   }, [open]);
 


### PR DESCRIPTION
## 📝 변경사항
- 관리자 dashboard에서 excel 버튼을 통해 원하는 날짜/필터링을 이용해 report를 excel로 다운로드

## 🔨 작업 내용
- [x] 엑셀로 데이터를 받아올 수 있게 API 연결
- [x] 필터링을 설정하기 위한 모달 작성
- [x] 모달에 대한 storybook 작성

## 🧪 테스트 방법
1. admin dashboard에서 excel 버튼을 눌러 나오는 모달 확인 -> 원하는 날짜/필터링 선택 -> 다운로드를 통해 실제 excel이 나오는지 확인

## 📸 스크린샷 (UI 변경 시)
<img width="512" height="567" alt="image" src="https://github.com/user-attachments/assets/df999bd0-5cca-4716-ba53-a8b5e6f38f17" />


## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [ ] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #186 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 구매 요청 데이터를 Excel로 내보내기(기간 선택, 상태·역할 필터) 기능 추가
  * 대시보드에 내보내기 버튼 및 모달 통합 — 진행 상태 표시, 파일 다운로드 트리거, 성공/오류 알림 제공
  * 모달 기본 날짜 범위는 이번 달(첫날~오늘)로 초기화되며, 날짜 유효성 검사와 로딩 상태가 반영됨

* **문서 / 스토리북**
  * Excel 내보내기 모달의 Storybook 예제 추가(열림/로딩/닫힘 상태)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->