### PR TITLE
refactor: remove sticky header positioning from auth header (#125)

### DIFF
--- a/src/components/organisms/AuthHeader/AuthHeader.tsx
+++ b/src/components/organisms/AuthHeader/AuthHeader.tsx
@@ -12,7 +12,6 @@ const AuthHeader = ({ className }: AuthHeaderProps) => (
   <div
     className={clsx(
       'auth-header-container',
-      'sticky top-0 z-header',
       'w-full h-56',
       'bg-white border-b border-gray-200',
       'flex items-center justify-between',

--- a/src/components/organisms/GNB/GNB.tsx
+++ b/src/components/organisms/GNB/GNB.tsx
@@ -113,7 +113,6 @@ const GNB = ({ baseState, handlers, navigationState, categoryState }: GNBProps) 
     <div
       className={clsx(
         'gnb-container',
-        'sticky top-0 z-header',
         'w-full h-56',
         'bg-white border-b border-gray-200',
         'flex items-center justify-between',


### PR DESCRIPTION
## 📝 변경사항
AuthHeader와 GNB에서 sticky 레이아웃을 제거하여 GNB 공통화 정책을 적용했습니다.

## 🔨 작업 내용
- [x] AuthHeader 컴포넌트에서 `sticky top-0 z-header` 제거
- [x] GNB 컴포넌트에서 `sticky top-0 z-header` 제거
- [x] GNB 공통화 정책에 따라 모든 GNB 관련 컴포넌트의 sticky 속성 사용 중지

## 🧪 테스트 방법
1. 로그인/비로그인 상태에서 GNB가 정상 노출되는지 확인
2. 페이지 스크롤 시 GNB가 sticky로 고정되지 않는지 확인
3. 모바일/데스크탑 모두에서 레이아웃 깨짐이 없는지 확인

## 📸 스크린샷 (UI 변경 시)
| Before | After |
|--------|-------|
| 이미지 | 이미지 |

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI 변경사항**
  * 상단 헤더의 고정 위치 지정 기능이 제거되었습니다. 페이지 스크롤 시 헤더가 화면 상단에 고정되지 않고 페이지와 함께 스크롤됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->