### PR TITLE
refactor: unify admin and dashboard layout spacing (#125)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,6 +211,7 @@ body {
   --spacing-97: 97px;
   --spacing-99: 99px;
   --spacing-100: 100px;
+  --spacing-104: 104px;
   --spacing-105: 105px;
   --spacing-110: 110px;
   --spacing-120: 120px;
@@ -367,8 +368,8 @@ body {
   @media (min-width: 1024px) {
     .gnb-container,
     .auth-header-container {
-      padding-left: 100px !important;
-      padding-right: 100px !important;
+      padding-left: 70px !important;
+      padding-right: 70px !important;
     }
   }
 

--- a/src/components/molecules/AdminSideBar/AdminSideBar.tsx
+++ b/src/components/molecules/AdminSideBar/AdminSideBar.tsx
@@ -110,9 +110,12 @@ export const AdminSidebar = ({ companyId, userRole = 'user' }: AdminSidebarProps
   const usersHref = PATHNAME.ADMIN_USERS(companyId);
   const budgetHref = PATHNAME.ADMIN_BUDGET(companyId);
 
-  const isDashboardPage = pathname ? pathname.includes('/admin/dashboard') : false;
   const isUsersPage = pathname ? pathname.includes('/admin/users') : false;
   const isBudgetPage = pathname ? pathname.includes('/admin/budget') : false;
+
+  const isDashboardPage = pathname
+    ? pathname.includes('/admin/dashboard') || (!isUsersPage && !isBudgetPage)
+    : true;
 
   return (
     <>

--- a/src/features/admin/budget/template/AdminBudgetTem.tsx
+++ b/src/features/admin/budget/template/AdminBudgetTem.tsx
@@ -26,7 +26,7 @@ const AdminBudgetTemplate = ({
   return (
     <div className="flex flex-col desktop:flex-row w-full min-h-screen bg-white">
       {/* 어드민 sidebar */}
-      <div className="shrink-0 desktop:border-r border-gray-100">
+      <div className="shrink-0">
         <div className="desktop:p-24 desktop:w-260 desktop:sticky desktop:top-0 h-full">
           <AdminSidebar companyId={companyId} userRole="admin" />
         </div>

--- a/src/features/admin/users/template/AdminUserTem.tsx
+++ b/src/features/admin/users/template/AdminUserTem.tsx
@@ -35,7 +35,7 @@ const AdminUsersTemplate = ({
   return (
     <div className="flex flex-col desktop:flex-row w-full min-h-screen bg-white">
       {/* 어드민 sidebar */}
-      <div className="shrink-0 desktop:border-r border-gray-100">
+      <div className="shrink-0">
         <div className="desktop:p-24 desktop:w-260 desktop:sticky desktop:top-0 h-full">
           <AdminSidebar companyId={companyId} userRole="admin" />
         </div>

--- a/src/features/dashboard/components/DashboardCardOrg/DashboardCardOrg.tsx
+++ b/src/features/dashboard/components/DashboardCardOrg/DashboardCardOrg.tsx
@@ -223,7 +223,7 @@ const DashboardCardOrg = ({
 
           <div className="w-full flex-1 overflow-y-auto scrollbar-none">
             <table className="w-full table-fixed text-12 text-gray-700">
-              <thead className="sticky top-0 bg-gray-50 z-20 shadow-sm">
+              <thead className="sticky top-0 bg-gray-50 shadow-sm">
                 <tr className="border-b border-gray-200">
                   <th className="w-1/4 text-left py-6">이름</th>
                   <th className="w-2/4 text-left py-6">이메일</th>
@@ -291,8 +291,8 @@ const DashboardCardOrg = ({
         <div className="w-full h-full flex flex-col gap-12">
           <span className="text-14 font-medium text-gray-900">이번 달 요청한 간식 순위</span>
 
-          <div className="flex flex-col tablet:flex-row desktop:flex-col items-start flex-1 gap-16 overflow-hidden">
-            <div className="shrink-0 w-200 h-200 desktop:w-208 desktop:h-208 desktop:self-center">
+          <div className="flex flex-col tablet:flex-row desktop:flex-col items-start flex-1 gap-16 overflow-hidden tablet:h-320">
+            <div className="shrink-0 w-200 h-200 tablet:w-110 tablet:h-110 desktop:w-208 desktop:h-208 desktop:self-center">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                   <Pie
@@ -314,7 +314,7 @@ const DashboardCardOrg = ({
               </ResponsiveContainer>
             </div>
 
-            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none">
+            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none tablet:max-h-full">
               {largeChartData.map((item, index) => (
                 <li key={item.label} className="flex items-center gap-8">
                   <span className="text-gray-400 w-12">{index + 1}.</span>
@@ -337,7 +337,7 @@ const DashboardCardOrg = ({
           <span className="text-14 font-medium text-gray-900">이번 달 요청한 간식 순위</span>
 
           {/* 모바일: 차트 위, 리스트 아래 / 태블릿+: 좌우 배치 */}
-          <div className="flex flex-col tablet:flex-row items-start flex-1 gap-16 tablet:gap-20 overflow-hidden">
+          <div className="flex flex-col tablet:flex-row items-start flex-1 gap-16 tablet:gap-20 overflow-hidden tablet:h-320">
             <div className="self-center tablet:self-auto shrink-0 w-180 h-180 tablet:w-220 tablet:h-220 desktop:w-180 desktop:h-180">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
@@ -360,7 +360,7 @@ const DashboardCardOrg = ({
               </ResponsiveContainer>
             </div>
 
-            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none max-h-160 tablet:max-h-none">
+            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none max-h-160 tablet:max-h-full">
               {largeChartData.map((item, index) => (
                 <li key={item.label} className="flex items-center gap-8">
                   <span className="text-gray-400 w-12">{index + 1}.</span>

--- a/src/features/dashboard/template/DashboardTem/DashboardTem.tsx
+++ b/src/features/dashboard/template/DashboardTem/DashboardTem.tsx
@@ -175,8 +175,9 @@ const DashboardTem = ({
         desktop:flex-row
         desktop:w-full
         desktop:max-w-1400
-        desktop:pl-70
+        desktop:pl-25
         desktop:pr-100
+        desktop:mt-104
       "
     >
       {/* ===== Mobile / Tablet Title ===== */}
@@ -231,7 +232,7 @@ const DashboardTem = ({
       </div>
 
       {/* ===== Dashboard Content ===== */}
-      <main className="flex flex-col desktop:ml-50 flex-1 min-w-0">
+      <main className="flex flex-col desktop:ml-90 flex-1 min-w-0">
         {/* ===== Desktop Title ===== */}
         <div
           className="


### PR DESCRIPTION
## 📝 변경사항
어드민 및 대시보드 전반의 레이아웃 여백과 UI 스타일을
디자인 가이드에 맞게 통일하고,
사이드바 및 대시보드 활성화 로직을 개선했습니다.

## 🔨 작업 내용
- [x] globals.css에 spacing 토큰(--spacing-104) 추가
- [x] 데스크톱 좌우 패딩 값 100px → 70px로 조정
- [x] 관리자 사이드바 active 상태 판별 로직 보완
- [x] 어드민 예산/회원 관리 페이지 sidebar border 제거
- [x] 대시보드 카드 레이아웃 및 스크롤 구조 리팩토링
- [x] 대시보드 템플릿 desktop 여백 및 정렬 구조 개선

## 🧪 테스트 방법
1. admin 계정으로 로그인
2. 대시보드 / 회원 관리 / 예산 관리 페이지 이동
3. 각 메뉴 active 상태 정상 표시 여부 확인
4. desktop / tablet / mobile 해상도에서 레이아웃 확인

## 📸 스크린샷 (UI 변경 시)

| Before | After |
|--------|-------|
| (첨부 예정) | (첨부 예정) |

## ✅ 체크리스트
- [x] 코드 스타일 가이드를 준수했습니다
- [x] 주요 로직에 주석을 작성했습니다
- [x] 테스트 코드를 작성했습니다
- [x] 문서를 업데이트했습니다 (필요 시)
- [x] 이슈를 연결했습니다

## 🔗 관련 이슈
Closes #125


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 대시보드의 데스크톱 패딩 및 여백 조정으로 레이아웃 간격 개선
  * 관리자 사이드바의 데스크톱 보더 스타일 제거
  * 태블릿과 데스크톱의 반응형 크기 조정으로 디스플레이 최적화

* **개선**
  * 네비게이션 활성 상태 로직 개선으로 관리자 페이지 네비게이션 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->