### PR TITLE
[Jan-21-2026] Release: Develop → Main : In-Memory Auth Initialization and Test/E2E Hardening

### DIFF
--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -7,8 +7,77 @@ import { test, expect } from '@playwright/test';
  */
 
 // 테스트 계정 정보
-const TEST_EMAIL = 'test003@test001.com';
-const TEST_PASSWORD = '!Q2w3e4r';
+// - CI/로컬에서 계정이 다를 수 있으므로 env로 주입 가능하게 한다.
+// - 예) E2E_EMAIL="..." E2E_PASSWORD="..." npm run test:e2e
+const TEST_EMAIL = process.env.E2E_EMAIL ?? 'test003@test001.com';
+const TEST_PASSWORD = process.env.E2E_PASSWORD ?? '!Q2w3e4r';
+
+function getLoginEmailInput(page: import('@playwright/test').Page) {
+  // label 연결(접근성)을 기준으로 찾는다 (mobile/desktop 중복 렌더링에도 안전)
+  return page.getByRole('textbox', { name: '이메일' }).first();
+}
+
+function getLoginPasswordInput(page: import('@playwright/test').Page) {
+  return page.getByRole('textbox', { name: '비밀번호' }).first();
+}
+
+async function loginAndGetCompanyId(page: import('@playwright/test').Page): Promise<string> {
+  await page.goto('/login');
+  await getLoginEmailInput(page).fill(TEST_EMAIL);
+  await getLoginPasswordInput(page).fill(TEST_PASSWORD);
+  await page.getByRole('button', { name: '로그인' }).first().click();
+
+  // 로그인 응답을 먼저 기다려서 "회사 선택 필요(409)" 케이스를 안정적으로 처리
+  const companyDialog = page.getByRole('dialog', { name: '회사 선택' });
+  const toast = page.getByRole('status');
+
+  let loginStatus: number | null = null;
+  try {
+    const loginResponse = await page.waitForResponse(
+      (res) =>
+        res.request().method() === 'POST' &&
+        // Next rewrite로 same-origin(/api/...) 요청이 발생하므로 path만 체크해도 충분
+        res.url().includes('/api/v1/auth/login'),
+      { timeout: 45_000 }
+    );
+    loginStatus = loginResponse.status();
+  } catch {
+    // 응답 자체가 없으면(네트워크 단절/서버 미기동/브라우저 레벨 실패)
+    // 토스트가 떠 있으면 메시지로 안내하고, 아니면 URL 정보만 포함해 throw
+    if (await toast.isVisible().catch(() => false)) {
+      const message = (await toast.textContent())?.trim() || '(toast message not found)';
+      throw new Error(`로그인 요청이 실패/중단되었습니다. url=${page.url()} toast=${message}`);
+    }
+    throw new Error(`로그인 응답을 받지 못했습니다. url=${page.url()}`);
+  }
+
+  if (loginStatus === 409) {
+    // 회사 선택 모달이 열리고, 선택 후 "로그인"을 눌러야 리다이렉트됨
+    await companyDialog.waitFor({ state: 'visible', timeout: 10_000 });
+    await companyDialog.locator('button').first().click();
+    await companyDialog
+      .getByRole('button', { name: /로그인/ })
+      .first()
+      .click();
+  } else if (loginStatus && loginStatus >= 400) {
+    // 401/404/500 등: 보통 토스트로 안내되므로 토스트 텍스트를 포함해 에러로 만든다
+    if (await toast.isVisible().catch(() => false)) {
+      const message = (await toast.textContent())?.trim() || '(toast message not found)';
+      throw new Error(`로그인 실패(status=${loginStatus}). url=${page.url()} toast=${message}`);
+    }
+    throw new Error(`로그인 실패(status=${loginStatus}). url=${page.url()}`);
+  }
+
+  await page.waitForURL(/\/products/, { timeout: 45_000 });
+
+  const currentUrl = page.url();
+  const match = currentUrl.match(/\/([^/]+)\/products/);
+  const companyId = match?.[1];
+  if (!companyId) {
+    throw new Error(`companyId를 URL에서 찾지 못했습니다. url=${currentUrl}`);
+  }
+  return companyId;
+}
 
 test.describe('로그인 페이지', () => {
   test.beforeEach(async ({ page }) => {
@@ -25,11 +94,11 @@ test.describe('로그인 페이지', () => {
     });
 
     test('이메일 입력 필드가 표시된다', async ({ page }) => {
-      await expect(page.getByRole('textbox', { name: '이메일' }).first()).toBeVisible();
+      await expect(getLoginEmailInput(page)).toBeVisible();
     });
 
     test('비밀번호 입력 필드가 표시된다', async ({ page }) => {
-      await expect(page.getByRole('textbox', { name: '비밀번호' }).first()).toBeVisible();
+      await expect(getLoginPasswordInput(page)).toBeVisible();
     });
   });
 
@@ -40,8 +109,8 @@ test.describe('로그인 페이지', () => {
     });
 
     test('유효한 입력 후 로그인 버튼이 활성화된다', async ({ page }) => {
-      await page.getByRole('textbox', { name: '이메일' }).first().fill('test@example.com');
-      await page.getByRole('textbox', { name: '비밀번호' }).first().fill('Password123!');
+      await getLoginEmailInput(page).fill('test@example.com');
+      await getLoginPasswordInput(page).fill('Password123!');
 
       const loginButton = page.getByRole('button', { name: '로그인' }).first();
       await expect(loginButton).toBeEnabled();
@@ -50,34 +119,20 @@ test.describe('로그인 페이지', () => {
 
   test.describe('실제 로그인 테스트', () => {
     test('유효한 자격 증명으로 로그인 성공 후 리다이렉트된다', async ({ page }) => {
-      // 이메일 입력
-      await page.getByRole('textbox', { name: '이메일' }).first().fill(TEST_EMAIL);
-
-      // 비밀번호 입력
-      await page.getByRole('textbox', { name: '비밀번호' }).first().fill(TEST_PASSWORD);
-
-      // 로그인 버튼 클릭
-      await page.getByRole('button', { name: '로그인' }).first().click();
-
-      // 로그인 성공 후 리다이렉트 확인 (products 페이지로 이동)
-      await expect(page).toHaveURL(/\/products/, { timeout: 15000 });
+      await loginAndGetCompanyId(page);
+      await expect(page).toHaveURL(/\/products/, { timeout: 30000 });
     });
 
     test('로그인 후 상품 목록 페이지가 표시된다', async ({ page }) => {
-      await page.getByRole('textbox', { name: '이메일' }).first().fill(TEST_EMAIL);
-      await page.getByRole('textbox', { name: '비밀번호' }).first().fill(TEST_PASSWORD);
-      await page.getByRole('button', { name: '로그인' }).first().click();
-
-      // 상품 목록 페이지 로드 대기
-      await page.waitForURL(/\/products/, { timeout: 15000 });
+      await loginAndGetCompanyId(page);
 
       // 페이지가 로드되었는지 확인
       await expect(page.locator('body')).toBeVisible();
     });
 
     test('잘못된 비밀번호로 로그인 실패 시 로그인 페이지에 머무른다', async ({ page }) => {
-      await page.getByRole('textbox', { name: '이메일' }).first().fill(TEST_EMAIL);
-      await page.getByRole('textbox', { name: '비밀번호' }).first().fill('wrongpassword');
+      await getLoginEmailInput(page).fill(TEST_EMAIL);
+      await getLoginPasswordInput(page).fill('wrongpassword');
       await page.getByRole('button', { name: '로그인' }).first().click();
 
       // 로그인 페이지에 머무름
@@ -86,8 +141,8 @@ test.describe('로그인 페이지', () => {
     });
 
     test('존재하지 않는 이메일로 로그인 실패', async ({ page }) => {
-      await page.getByRole('textbox', { name: '이메일' }).first().fill('nonexistent@test.com');
-      await page.getByRole('textbox', { name: '비밀번호' }).first().fill('Password123!');
+      await getLoginEmailInput(page).fill('nonexistent@test.com');
+      await getLoginPasswordInput(page).fill('Password123!');
       await page.getByRole('button', { name: '로그인' }).first().click();
 
       // 로그인 페이지에 머무름
@@ -124,13 +179,10 @@ test.describe('회원가입 페이지', () => {
 });
 
 test.describe('로그인 후 페이지 접근', () => {
+  let companyId: string;
+
   test.beforeEach(async ({ page }) => {
-    // 로그인 수행
-    await page.goto('/login');
-    await page.getByRole('textbox', { name: '이메일' }).first().fill(TEST_EMAIL);
-    await page.getByRole('textbox', { name: '비밀번호' }).first().fill(TEST_PASSWORD);
-    await page.getByRole('button', { name: '로그인' }).first().click();
-    await page.waitForURL(/\/products/, { timeout: 15000 });
+    companyId = await loginAndGetCompanyId(page);
   });
 
   test('로그인 후 상품 목록 페이지에 접근할 수 있다', async ({ page }) => {
@@ -138,22 +190,84 @@ test.describe('로그인 후 페이지 접근', () => {
   });
 
   test('로그인 후 장바구니 페이지에 접근할 수 있다', async ({ page }) => {
-    // 현재 URL에서 companyId 추출
-    const currentUrl = page.url();
-    const match = currentUrl.match(/\/(\d+)\/products/);
-    expect(match).not.toBeNull();
-    const companyId = match![1];
     await page.goto(`/${companyId}/cart`);
     await expect(page).toHaveURL(`/${companyId}/cart`);
   });
 
   test('로그인 후 찜목록 페이지에 접근할 수 있다', async ({ page }) => {
-    const currentUrl = page.url();
-    const match = currentUrl.match(/\/(\d+)\/products/);
-    expect(match).not.toBeNull();
-    const companyId = match![1];
     await page.goto(`/${companyId}/wishlist`);
     await expect(page).toHaveURL(`/${companyId}/wishlist`);
+  });
+});
+
+test.describe('토큰 저장 방식 마이그레이션 (메모리 기반) QA', () => {
+  test('로그인 후 새로고침해도 인증이 유지된다 (refresh로 복원)', async ({ page }) => {
+    await loginAndGetCompanyId(page);
+
+    // 새로고침(메모리 초기화) 후에도 refreshToken(cookie)로 복원되어 /login으로 가지 않아야 함
+    await page.reload();
+    await expect(page).toHaveURL(/\/products/, { timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // localStorage에 auth-storage가 남아있지 않아야 함
+    const legacy = await page.evaluate(() => window.localStorage.getItem('auth-storage'));
+    expect(legacy).toBeNull();
+  });
+
+  test('쿠키 삭제(로그아웃에 준하는 상태) 후 새로고침하면 로그인 페이지로 유도된다', async ({
+    page,
+  }) => {
+    const companyId = await loginAndGetCompanyId(page);
+
+    // refreshToken(httpOnly) 포함 모든 쿠키 제거 = 로그아웃 상태로 가정
+    await page.context().clearCookies();
+
+    // 보호 라우트에서 새로고침 → refresh 실패 → /login으로 이동해야 함
+    await page.goto(`/${companyId}/products`);
+    await page.reload();
+    await expect(page).toHaveURL(/\/login/, { timeout: 15000 });
+  });
+
+  test('API 호출 중 401 발생 시 refresh로 복구된다 (상품 목록 API 1회 401 강제)', async ({
+    page,
+  }) => {
+    const companyId = await loginAndGetCompanyId(page);
+
+    // 초기 로그인 플로우에서 벗어나도록 다른 페이지로 이동
+    await page.goto(`/${companyId}/cart`);
+
+    let refreshCallCount = 0;
+    const onRequest = (req: import('@playwright/test').Request) => {
+      const url = req.url();
+      if (url.includes('/api/auth/refresh') || url.includes('/api/v1/auth/refresh')) {
+        refreshCallCount += 1;
+      }
+    };
+    page.on('request', onRequest);
+
+    // 상품 목록 API를 1회만 401로 강제
+    let forced401 = false;
+    await page.route('**/api/v1/product**', async (route) => {
+      if (!forced401) {
+        forced401 = true;
+        await route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Unauthorized (forced by e2e)' }),
+        });
+        return;
+      }
+      await route.continue();
+    });
+
+    // 상품 목록으로 이동 → 첫 요청 401 → refresh 호출 → 재시도 후 정상 렌더
+    await page.goto(`/${companyId}/products`);
+    await expect(page).toHaveURL(/\/products/, { timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/login/);
+    await expect(page.locator('body')).toBeVisible();
+
+    // 401을 처리하기 위해 refresh가 실제로 호출되었는지 확인
+    await expect.poll(() => refreshCallCount, { timeout: 15000 }).toBeGreaterThan(0);
   });
 });
 
@@ -163,7 +277,7 @@ test.describe('반응형 디자인', () => {
     await page.goto('/login');
 
     await expect(page.getByRole('heading', { name: '로그인' }).first()).toBeVisible();
-    await expect(page.getByRole('textbox', { name: '이메일' }).first()).toBeVisible();
+    await expect(getLoginEmailInput(page)).toBeVisible();
   });
 
   test('데스크톱에서 로그인 폼이 표시된다', async ({ page }) => {
@@ -171,6 +285,6 @@ test.describe('반응형 디자인', () => {
     await page.goto('/login');
 
     await expect(page.getByRole('heading', { name: '로그인' }).first()).toBeVisible();
-    await expect(page.getByRole('textbox', { name: '이메일' }).first()).toBeVisible();
+    await expect(getLoginEmailInput(page)).toBeVisible();
   });
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,8 +3,13 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright E2E 테스트 설정
  * @see https://playwright.dev/docs/test-configuration
+ *
+ * EMFILE 에러 방지:
+ * - 로컬 개발 시: 별도 터미널에서 'npm run dev'를 먼저 실행하세요
+ * - CI 환경에서는 자동으로 서버가 시작됩니다
  */
-export default defineConfig({
+
+const config = defineConfig({
   // 테스트 파일 디렉토리
   testDir: './e2e',
 
@@ -20,13 +25,16 @@ export default defineConfig({
   // CI 환경에서는 단일 워커 사용
   workers: process.env.CI ? 1 : undefined,
 
-  // HTML 리포터
-  reporter: [['html', { open: 'never' }]],
+  // 리포터
+  // - 로컬에서 "아무 출력이 없다"는 혼란을 줄이기 위해 line + html 병행
+  reporter: [['line'], ['html', { open: 'never' }]],
 
   // 공통 설정
   use: {
     // 기본 URL
-    baseURL: 'http://localhost:3000',
+    // localhost는 환경에 따라 IPv6(::1)로 해석되어 dev server 준비 대기에서 타임아웃될 수 있어
+    // IPv4 loopback을 명시합니다.
+    baseURL: 'http://127.0.0.1:3000',
 
     // 실패 시 트레이스 수집
     trace: 'on-first-retry',
@@ -49,12 +57,18 @@ export default defineConfig({
       use: { ...devices['Pixel 5'] },
     },
   ],
-
-  // 테스트 전 개발 서버 시작
-  webServer: {
-    command: 'npm run dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: true,
-    timeout: 120 * 1000,
-  },
 });
+
+// CI 환경에서만 webServer 설정 추가
+if (process.env.CI) {
+  config.webServer = {
+    command: 'npm run dev -- --hostname 127.0.0.1 --port 3000',
+    // Playwright는 webServer 준비 여부를 url로 폴링합니다.
+    // 현재 앱은 루트(/)가 404일 수 있으므로, 200이 보장되는 경로로 체크합니다.
+    url: 'http://127.0.0.1:3000/login',
+    reuseExistingServer: false,
+    timeout: 120 * 1000,
+  };
+}
+
+export default config;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -211,6 +211,7 @@ body {
   --spacing-97: 97px;
   --spacing-99: 99px;
   --spacing-100: 100px;
+  --spacing-104: 104px;
   --spacing-105: 105px;
   --spacing-110: 110px;
   --spacing-120: 120px;
@@ -367,8 +368,8 @@ body {
   @media (min-width: 1024px) {
     .gnb-container,
     .auth-header-container {
-      padding-left: 100px !important;
-      padding-right: 100px !important;
+      padding-left: 70px !important;
+      padding-right: 70px !important;
     }
   }
 

--- a/src/components/auth/AuthGuard.tsx
+++ b/src/components/auth/AuthGuard.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuthStore } from '@/lib/store/authStore';
-import { tryRefreshToken } from '@/utils/api';
 import { hasAccess } from '@/utils/auth';
 import { PATHNAME } from '@/constants';
 
@@ -18,59 +17,47 @@ interface AuthGuardProps {
  * - 인증되지 않은 사용자를 로그인 페이지로 리다이렉트
  * - 권한이 없는 사용자를 홈으로 리다이렉트
  * - Zustand store의 인증 정보 사용
+ * - 초기화(refreshToken으로 복원)는 providers.tsx에서 처리됨
  */
 export const AuthGuard = ({ children, companyId }: AuthGuardProps) => {
   const router = useRouter();
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
   const accessToken = useAuthStore((state) => state.accessToken);
-  const clearAuth = useAuthStore((state) => state.clearAuth);
-  const isHydrated = useAuthStore((state) => state.isHydrated);
-  const refreshAttemptedRef = useRef(false);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
 
   useEffect(() => {
-    if (!isHydrated) return;
+    // 초기화 완료 전에는 대기 (providers.tsx에서 로딩 표시 중)
+    if (!isInitialized) return;
 
-    // accessToken이 없으면 refreshToken(httpOnly 쿠키)로 복구 시도
+    // 초기화 완료 후 accessToken이 없으면 로그인 필요
     if (!accessToken) {
-      if (refreshAttemptedRef.current) return;
-      refreshAttemptedRef.current = true;
-      (async () => {
-        try {
-          const newToken = await tryRefreshToken();
-          if (!newToken) {
-            // refresh token 만료/없음(401)이어도 여기서 localStorage를 지우면
-            // "포커스 복귀 시 갑자기 로그아웃"처럼 보일 수 있음 → 리다이렉트만 수행
-            const loginUrl = `${PATHNAME.LOGIN}?redirect=${encodeURIComponent(pathname)}`;
-            router.push(loginUrl);
-          }
-        } catch {
-          // 일시 장애(네트워크/타임아웃)로 refresh 실패 시에는 localStorage를 지우지 않음
-          const loginUrl = `${PATHNAME.LOGIN}?redirect=${encodeURIComponent(pathname)}`;
-          router.push(loginUrl);
-        }
-      })().catch(() => {});
+      const loginUrl = `${PATHNAME.LOGIN}?redirect=${encodeURIComponent(pathname)}`;
+      router.push(loginUrl);
       return;
     }
 
+    // user 정보가 없으면 로그인 필요
     if (!user) {
       const loginUrl = `${PATHNAME.LOGIN}?redirect=${encodeURIComponent(pathname)}`;
       router.push(loginUrl);
       return;
     }
 
+    // 다른 회사 사용자는 자신의 회사 페이지로 리다이렉트
     if (user.companyId !== companyId) {
       router.push(PATHNAME.PRODUCTS(user.companyId));
       return;
     }
 
+    // 권한이 없으면 상품 페이지로 리다이렉트
     if (!hasAccess(user.role, pathname)) {
       router.push(PATHNAME.PRODUCTS(user.companyId));
     }
-  }, [user, accessToken, clearAuth, companyId, pathname, router, isHydrated]);
+  }, [user, accessToken, companyId, pathname, router, isInitialized]);
 
-  // 하이드레이션 완료 전까지는 로딩 상태 표시
-  if (!isHydrated) {
+  // 초기화 완료 전에는 null 반환 (providers.tsx에서 로딩 표시 중)
+  if (!isInitialized) {
     return null;
   }
 

--- a/src/components/auth/__tests__/AuthGuard.test.tsx
+++ b/src/components/auth/__tests__/AuthGuard.test.tsx
@@ -1,0 +1,339 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+
+// logger mock
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Next.js navigation mock
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+let mockPathname = '/company-1/products';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => mockPathname,
+}));
+
+// tryRefreshToken mock
+const mockTryRefreshToken = vi.fn();
+vi.mock('@/utils/api', () => ({
+  tryRefreshToken: () => mockTryRefreshToken(),
+}));
+
+// hasAccess mock
+const mockHasAccess = vi.fn();
+vi.mock('@/utils/auth', () => ({
+  hasAccess: (role: string, pathname: string) => mockHasAccess(role, pathname),
+}));
+
+// constants mock
+vi.mock('@/constants', () => ({
+  PATHNAME: {
+    LOGIN: '/login',
+    PRODUCTS: (companyId: string) => `/${companyId}/products`,
+  },
+}));
+
+// authStore mock
+interface MockUser {
+  id: string;
+  email: string;
+  name: string;
+  role: 'user' | 'manager' | 'admin';
+  companyId: string;
+}
+
+interface MockStoreState {
+  user: MockUser | null;
+  accessToken: string | null;
+  isHydrated: boolean;
+  clearAuth: () => void;
+}
+
+let mockStoreState: MockStoreState = {
+  user: null,
+  accessToken: null,
+  isHydrated: false,
+  clearAuth: vi.fn(),
+};
+
+vi.mock('@/lib/store/authStore', () => ({
+  useAuthStore: (selector: (state: MockStoreState) => unknown) => selector(mockStoreState),
+}));
+
+// 테스트용 컴포넌트
+const TestChild = () => <div data-testid="protected-content">Protected Content</div>;
+
+describe('AuthGuard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockPathname = '/company-1/products';
+    mockHasAccess.mockReturnValue(true);
+    mockTryRefreshToken.mockReset();
+    mockPush.mockReset();
+    mockReplace.mockReset();
+
+    // Reset store state
+    mockStoreState = {
+      user: null,
+      accessToken: null,
+      isHydrated: false,
+      clearAuth: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('하이드레이션 전', () => {
+    it('isHydrated가 false면 null을 렌더링한다', async () => {
+      mockStoreState.isHydrated = false;
+
+      const { AuthGuard } = await import('../AuthGuard');
+      const { container } = render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      expect(container.firstChild).toBeNull();
+      expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('하이드레이션 후 - 인증되지 않은 경우', () => {
+    it('accessToken이 없으면 refresh를 시도한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = null;
+      mockStoreState.user = null;
+
+      mockTryRefreshToken.mockResolvedValueOnce(null);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockTryRefreshToken).toHaveBeenCalled();
+      });
+    });
+
+    it('refresh 실패 시 로그인 페이지로 리다이렉트한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = null;
+      mockStoreState.user = null;
+
+      mockTryRefreshToken.mockResolvedValueOnce(null);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('/login?redirect='));
+      });
+    });
+
+    it('user가 없으면 로그인 페이지로 리다이렉트한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = 'valid-token';
+      mockStoreState.user = null;
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(expect.stringContaining('/login?redirect='));
+      });
+    });
+  });
+
+  describe('하이드레이션 후 - 인증된 경우', () => {
+    it('올바른 companyId와 권한이 있으면 children을 렌더링한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = 'valid-token';
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+
+      mockHasAccess.mockReturnValue(true);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+    });
+
+    it('다른 companyId면 올바른 회사 페이지로 리다이렉트한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = 'valid-token';
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-2', // 다른 companyId
+      };
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/company-2/products');
+      });
+    });
+
+    it('권한이 없으면 products 페이지로 리다이렉트한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = 'valid-token';
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+
+      mockHasAccess.mockReturnValue(false); // 권한 없음
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith('/company-1/products');
+      });
+    });
+  });
+
+  describe('redirect 파라미터', () => {
+    it('로그인 리다이렉트 시 현재 경로를 redirect 파라미터로 포함한다', async () => {
+      mockPathname = '/company-1/admin/users';
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = null;
+      mockStoreState.user = null;
+
+      mockTryRefreshToken.mockResolvedValueOnce(null);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          `/login?redirect=${encodeURIComponent('/company-1/admin/users')}`
+        );
+      });
+    });
+  });
+
+  describe('토큰 갱신 중복 방지', () => {
+    it('refresh 시도는 한 번만 수행된다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = null;
+      mockStoreState.user = null;
+
+      mockTryRefreshToken.mockResolvedValue(null);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      const { rerender } = render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      // 리렌더링
+      rerender(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      rerender(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      await waitFor(() => {
+        // refreshAttemptedRef로 인해 한 번만 호출
+        expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+      });
+    });
+  });
+
+  describe('마이그레이션 후 동작 (isInitialized)', () => {
+    // 마이그레이션 후 isHydrated → isInitialized로 변경됨
+    // providers.tsx에서 이미 초기화를 담당하므로 AuthGuard는 단순화될 예정
+    it('초기화 상태에 따라 렌더링이 제어된다', async () => {
+      // 현재: isHydrated 사용
+      // 마이그레이션 후: isInitialized 사용, 초기화 로직은 providers.tsx로 이동
+      mockStoreState.isHydrated = true;
+      mockStoreState.accessToken = 'token';
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+
+      mockHasAccess.mockReturnValue(true);
+
+      const { AuthGuard } = await import('../AuthGuard');
+      render(
+        <AuthGuard companyId="company-1">
+          <TestChild />
+        </AuthGuard>
+      );
+
+      expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/auth/__tests__/AuthGuard.test.tsx
+++ b/src/components/auth/__tests__/AuthGuard.test.tsx
@@ -253,13 +253,11 @@ describe('AuthGuard', () => {
     });
   });
 
-  describe('토큰 갱신 중복 방지', () => {
-    it('refresh 시도는 한 번만 수행된다', async () => {
+  describe('리렌더링 안정성', () => {
+    it('리렌더링해도 정상 동작한다', async () => {
       mockStoreState.isInitialized = true;
       mockStoreState.accessToken = null;
       mockStoreState.user = null;
-
-      mockTryRefreshToken.mockResolvedValue(null);
 
       const { AuthGuard } = await import('../AuthGuard');
       const { rerender } = render(
@@ -281,9 +279,9 @@ describe('AuthGuard', () => {
         </AuthGuard>
       );
 
+      // 마이그레이션 후: AuthGuard는 refresh를 시도하지 않고 로그인으로 리다이렉트
       await waitFor(() => {
-        // refreshAttemptedRef로 인해 한 번만 호출
-        expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+        expect(mockPush).toHaveBeenCalled();
       });
     });
   });

--- a/src/components/auth/__tests__/AuthGuard.test.tsx
+++ b/src/components/auth/__tests__/AuthGuard.test.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 
 // logger mock
 vi.mock('@/utils/logger', () => ({

--- a/src/components/chatbot/ChatBot.tsx
+++ b/src/components/chatbot/ChatBot.tsx
@@ -41,7 +41,7 @@ const ChatBot = (): JSX.Element | null => {
   const [isOpen, setIsOpen] = useState(false);
   const [chatKey, setChatKey] = useState(0);
   const [previousUserId, setPreviousUserId] = useState<string | null>(null);
-  const { user, isHydrated } = useAuthStore();
+  const { user, isInitialized } = useAuthStore();
 
   // 사용자 role에 따라 동적으로 config 생성
   const config = useMemo(() => {
@@ -118,8 +118,8 @@ const ChatBot = (): JSX.Element | null => {
     }
   }, [user, previousUserId]);
 
-  // hydration이 완료될 때까지 대기
-  if (!isHydrated) {
+  // 초기화가 완료될 때까지 대기 (providers.tsx에서 로딩 표시 중)
+  if (!isInitialized) {
     return null;
   }
 

--- a/src/components/guards/RoleGuard.tsx
+++ b/src/components/guards/RoleGuard.tsx
@@ -20,7 +20,7 @@ export const RoleGuard = ({ children, requiredRole, fallback }: RoleGuardProps) 
   const pathname = usePathname();
   const user = useAuthStore((state) => state.user);
   const accessToken = useAuthStore((state) => state.accessToken);
-  const isHydrated = useAuthStore((state) => state.isHydrated);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
 
   const isRoleKnown = (role: UserRole | undefined): role is UserRole =>
     !!role && role in ROLE_LEVEL;
@@ -47,8 +47,8 @@ export const RoleGuard = ({ children, requiredRole, fallback }: RoleGuardProps) 
   }, [user?.role, pathname]);
 
   useEffect(() => {
-    // 하이드레이션이 완료되지 않았으면 리다이렉트하지 않음
-    if (!isHydrated) return;
+    // 초기화 완료 전에는 리다이렉트하지 않음 (providers.tsx에서 로딩 표시 중)
+    if (!isInitialized) return;
 
     if (!accessToken || !user) {
       router.replace(PATHNAME.LOGIN);
@@ -66,7 +66,7 @@ export const RoleGuard = ({ children, requiredRole, fallback }: RoleGuardProps) 
       redirectToSafePage();
     }
   }, [
-    isHydrated,
+    isInitialized,
     user,
     accessToken,
     router,
@@ -75,20 +75,9 @@ export const RoleGuard = ({ children, requiredRole, fallback }: RoleGuardProps) 
     redirectToSafePage,
   ]);
 
-  // 하이드레이션 완료 전까지는 로딩 상태 표시
-  if (!isHydrated) {
-    return (
-      <div
-        className="flex items-center justify-center min-h-screen"
-        aria-busy="true"
-        aria-live="polite"
-        role="status"
-        aria-label="인증 정보 확인 중"
-      >
-        <div className="w-24 h-24 border-2 border-gray-200 border-t-secondary-500 rounded-full animate-spin" />
-        <span className="sr-only">인증 정보 확인 중</span>
-      </div>
-    );
+  // 초기화 완료 전에는 null 반환 (providers.tsx에서 로딩 표시 중)
+  if (!isInitialized) {
+    return null;
   }
 
   if (!accessToken || !user) return null;

--- a/src/components/molecules/AdminSideBar/AdminSideBar.tsx
+++ b/src/components/molecules/AdminSideBar/AdminSideBar.tsx
@@ -110,9 +110,12 @@ export const AdminSidebar = ({ companyId, userRole = 'user' }: AdminSidebarProps
   const usersHref = PATHNAME.ADMIN_USERS(companyId);
   const budgetHref = PATHNAME.ADMIN_BUDGET(companyId);
 
-  const isDashboardPage = pathname ? pathname.includes('/admin/dashboard') : false;
   const isUsersPage = pathname ? pathname.includes('/admin/users') : false;
   const isBudgetPage = pathname ? pathname.includes('/admin/budget') : false;
+
+  const isDashboardPage = pathname
+    ? pathname.includes('/admin/dashboard') || (!isUsersPage && !isBudgetPage)
+    : true;
 
   return (
     <>

--- a/src/features/admin/budget/template/AdminBudgetTem.tsx
+++ b/src/features/admin/budget/template/AdminBudgetTem.tsx
@@ -26,7 +26,7 @@ const AdminBudgetTemplate = ({
   return (
     <div className="flex flex-col desktop:flex-row w-full min-h-screen bg-white">
       {/* 어드민 sidebar */}
-      <div className="shrink-0 desktop:border-r border-gray-100">
+      <div className="shrink-0">
         <div className="desktop:p-24 desktop:w-260 desktop:sticky desktop:top-0 h-full">
           <AdminSidebar companyId={companyId} userRole="admin" />
         </div>

--- a/src/features/admin/users/template/AdminUserTem.tsx
+++ b/src/features/admin/users/template/AdminUserTem.tsx
@@ -35,7 +35,7 @@ const AdminUsersTemplate = ({
   return (
     <div className="flex flex-col desktop:flex-row w-full min-h-screen bg-white">
       {/* 어드민 sidebar */}
-      <div className="shrink-0 desktop:border-r border-gray-100">
+      <div className="shrink-0">
         <div className="desktop:p-24 desktop:w-260 desktop:sticky desktop:top-0 h-full">
           <AdminSidebar companyId={companyId} userRole="admin" />
         </div>

--- a/src/features/auth/queries/auth.queries.ts
+++ b/src/features/auth/queries/auth.queries.ts
@@ -49,14 +49,6 @@ export function useLogin() {
       const { user, accessToken } = data;
       setAuth({ user, accessToken });
 
-      // localStorage에 저장되었는지 확인 (개발 환경에서만)
-      if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-        const stored = localStorage.getItem('auth-storage');
-        logger.info('[Login] localStorage 저장 확인:', {
-          hasStored: !!stored,
-        });
-      }
-
       logger.info('[Login] 인증 정보 저장 완료:', {
         hasUserId: !!user.id,
         role: user.role,

--- a/src/features/auth/template/LoginTem/LoginTem.tsx
+++ b/src/features/auth/template/LoginTem/LoginTem.tsx
@@ -35,6 +35,7 @@ interface LoginTemContentProps {
   isValid: boolean;
   onSubmit: (values: LoginInput) => void | Promise<void>;
   className?: string;
+  idPrefix: string;
 }
 
 const LoginTemContent = ({
@@ -43,6 +44,7 @@ const LoginTemContent = ({
   onSubmit,
   handleSubmit,
   className,
+  idPrefix,
 }: LoginTemContentProps) => {
   const handleFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -64,6 +66,9 @@ const LoginTemContent = ({
           label={field.label}
           placeholder={field.placeholder}
           type={field.type}
+          // mobile/desktop 템플릿을 동시에 렌더링하므로(반응형),
+          // 동일한 id(input-email 등)가 중복되면 label 연결이 깨질 수 있어 고유 id를 부여합니다.
+          id={`${idPrefix}-${field.name}`}
           className="w-full"
         />
       ))}
@@ -124,6 +129,7 @@ const LoginTem = (props: LoginTemProps) => {
         {/* eslint-disable-next-line react/jsx-props-no-spreading */}
         <LoginTemContent
           {...contentProps}
+          idPrefix="login-mobile"
           className="flex w-327 flex-col tablet:hidden desktop:hidden"
         />
         <p className="mt-24 text-center text-14 text-gray-600">
@@ -147,6 +153,7 @@ const LoginTem = (props: LoginTemProps) => {
             {/* eslint-disable-next-line react/jsx-props-no-spreading */}
             <LoginTemContent
               {...contentProps}
+              idPrefix="login-desktop"
               className="flex flex-col w-full tablet:w-480 desktop:w-480"
             />
             <p className="flex justify-center mt-24 text-14 text-gray-600 gap-5">

--- a/src/features/dashboard/components/DashboardCardOrg/DashboardCardOrg.tsx
+++ b/src/features/dashboard/components/DashboardCardOrg/DashboardCardOrg.tsx
@@ -223,7 +223,7 @@ const DashboardCardOrg = ({
 
           <div className="w-full flex-1 overflow-y-auto scrollbar-none">
             <table className="w-full table-fixed text-12 text-gray-700">
-              <thead className="sticky top-0 bg-gray-50 z-20 shadow-sm">
+              <thead className="sticky top-0 bg-gray-50 shadow-sm">
                 <tr className="border-b border-gray-200">
                   <th className="w-1/4 text-left py-6">이름</th>
                   <th className="w-2/4 text-left py-6">이메일</th>
@@ -291,8 +291,8 @@ const DashboardCardOrg = ({
         <div className="w-full h-full flex flex-col gap-12">
           <span className="text-14 font-medium text-gray-900">이번 달 요청한 간식 순위</span>
 
-          <div className="flex flex-col tablet:flex-row desktop:flex-col items-start flex-1 gap-16 overflow-hidden">
-            <div className="shrink-0 w-200 h-200 desktop:w-208 desktop:h-208 desktop:self-center">
+          <div className="flex flex-col tablet:flex-row desktop:flex-col items-start flex-1 gap-16 overflow-hidden tablet:h-320">
+            <div className="shrink-0 w-200 h-200 tablet:w-110 tablet:h-110 desktop:w-208 desktop:h-208 desktop:self-center">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
                   <Pie
@@ -314,7 +314,7 @@ const DashboardCardOrg = ({
               </ResponsiveContainer>
             </div>
 
-            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none">
+            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none tablet:max-h-full">
               {largeChartData.map((item, index) => (
                 <li key={item.label} className="flex items-center gap-8">
                   <span className="text-gray-400 w-12">{index + 1}.</span>
@@ -337,7 +337,7 @@ const DashboardCardOrg = ({
           <span className="text-14 font-medium text-gray-900">이번 달 요청한 간식 순위</span>
 
           {/* 모바일: 차트 위, 리스트 아래 / 태블릿+: 좌우 배치 */}
-          <div className="flex flex-col tablet:flex-row items-start flex-1 gap-16 tablet:gap-20 overflow-hidden">
+          <div className="flex flex-col tablet:flex-row items-start flex-1 gap-16 tablet:gap-20 overflow-hidden tablet:h-320">
             <div className="self-center tablet:self-auto shrink-0 w-180 h-180 tablet:w-220 tablet:h-220 desktop:w-180 desktop:h-180">
               <ResponsiveContainer width="100%" height="100%">
                 <PieChart>
@@ -360,7 +360,7 @@ const DashboardCardOrg = ({
               </ResponsiveContainer>
             </div>
 
-            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none max-h-160 tablet:max-h-none">
+            <ul className="w-full tablet:flex-1 flex flex-col gap-8 text-12 text-gray-700 overflow-y-auto scrollbar-none max-h-160 tablet:max-h-full">
               {largeChartData.map((item, index) => (
                 <li key={item.label} className="flex items-center gap-8">
                   <span className="text-gray-400 w-12">{index + 1}.</span>

--- a/src/features/dashboard/section/DashboardSection.tsx
+++ b/src/features/dashboard/section/DashboardSection.tsx
@@ -126,7 +126,7 @@ const transformDashboardData = (data: DashboardApiResponse) => {
 
 const DashboardSection = ({ companyId }: DashboardSectionProps) => {
   const user = useAuthStore((state) => state.user);
-  const isHydrated = useAuthStore((state) => state.isHydrated);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
   const [isLoading, setIsLoading] = useState(true);
   const [toastState, setToastState] = useState({
     isVisible: false,
@@ -198,13 +198,9 @@ const DashboardSection = ({ companyId }: DashboardSectionProps) => {
     });
   }, []); // 컴포넌트 마운트 시 한 번만 실행 (토큰에서 회사 정보 자동 추출)
 
-  // 하이드레이션이 완료되지 않은 경우 (Zustand persist 로딩 중)
-  if (!isHydrated) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <p>로딩 중...</p>
-      </div>
-    );
+  // 초기화가 완료되지 않은 경우 (providers.tsx에서 로딩 표시 중이므로 여기서는 null 반환)
+  if (!isInitialized) {
+    return null;
   }
 
   // API 데이터 로딩 중
@@ -217,7 +213,7 @@ const DashboardSection = ({ companyId }: DashboardSectionProps) => {
   }
 
   // 사용자 정보가 없는 경우 (실제 비인증 상태)
-  // 이 시점에서는 isHydrated === true이므로 스토어가 완전히 로드된 상태
+  // 이 시점에서는 isInitialized === true이므로 초기화가 완료된 상태
   if (!user) {
     logger.warn('[Dashboard] 사용자 정보 없음 - 인증 필요');
     return (

--- a/src/features/dashboard/template/DashboardTem/DashboardTem.tsx
+++ b/src/features/dashboard/template/DashboardTem/DashboardTem.tsx
@@ -175,8 +175,9 @@ const DashboardTem = ({
         desktop:flex-row
         desktop:w-full
         desktop:max-w-1400
-        desktop:pl-70
+        desktop:pl-25
         desktop:pr-100
+        desktop:mt-104
       "
     >
       {/* ===== Mobile / Tablet Title ===== */}
@@ -231,7 +232,7 @@ const DashboardTem = ({
       </div>
 
       {/* ===== Dashboard Content ===== */}
-      <main className="flex flex-col desktop:ml-50 flex-1 min-w-0">
+      <main className="flex flex-col desktop:ml-90 flex-1 min-w-0">
         {/* ===== Desktop Title ===== */}
         <div
           className="

--- a/src/hooks/__tests__/useTokenRefresh.test.ts
+++ b/src/hooks/__tests__/useTokenRefresh.test.ts
@@ -1,0 +1,290 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return, @typescript-eslint/await-thenable */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// logger mock
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// tryRefreshToken mock
+const mockTryRefreshToken = vi.fn();
+vi.mock('@/utils/api', () => ({
+  tryRefreshToken: () => mockTryRefreshToken(),
+}));
+
+// authStore mock
+interface MockUser {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+}
+
+let mockStoreState = {
+  user: null as MockUser | null,
+  accessToken: null as string | null,
+  isHydrated: false,
+};
+
+vi.mock('@/lib/store/authStore', () => ({
+  useAuthStore: <T>(selector: (state: typeof mockStoreState) => T): T => selector(mockStoreState),
+}));
+
+describe('useTokenRefresh', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // Reset store state
+    mockStoreState = {
+      user: null,
+      accessToken: null,
+      isHydrated: false,
+    };
+
+    mockTryRefreshToken.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe('하이드레이션 전', () => {
+    it('isHydrated가 false면 아무 동작도 하지 않는다', async () => {
+      mockStoreState.isHydrated = false;
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh());
+
+      // 타이머 진행
+      await act(() => {
+        vi.advanceTimersByTime(5 * 60 * 1000);
+      });
+
+      expect(mockTryRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('하이드레이션 후 - user와 accessToken이 없는 경우', () => {
+    it('user도 accessToken도 없으면 refresh를 시도하지 않는다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = null;
+      mockStoreState.accessToken = null;
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh());
+
+      await act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(mockTryRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('하이드레이션 후 - user는 있지만 accessToken이 없는 경우', () => {
+    it('user가 있고 accessToken이 없으면 refresh를 시도한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = null;
+
+      mockTryRefreshToken.mockResolvedValueOnce('new-token');
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh());
+
+      await act(() => vi.advanceTimersByTimeAsync(100));
+
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('refresh 실패해도 에러를 throw하지 않는다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = null;
+
+      mockTryRefreshToken.mockRejectedValueOnce(new Error('Network error'));
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+
+      // 에러가 발생해도 훅은 정상 동작해야 함
+      expect(() => {
+        renderHook(() => useTokenRefresh());
+      }).not.toThrow();
+
+      await act(() => vi.advanceTimersByTimeAsync(100));
+    });
+  });
+
+  describe('주기적 토큰 갱신', () => {
+    it('user와 accessToken이 있으면 즉시 refresh를 실행한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = 'existing-token';
+
+      mockTryRefreshToken.mockResolvedValue('new-token');
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh());
+
+      await act(() => vi.advanceTimersByTimeAsync(100));
+
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshInterval마다 refresh를 실행한다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = 'existing-token';
+
+      mockTryRefreshToken.mockResolvedValue('new-token');
+
+      const refreshInterval = 4 * 60 * 1000; // 4분
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh(refreshInterval));
+
+      // 초기 호출
+      await act(() => vi.advanceTimersByTimeAsync(100));
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+
+      // 4분 후
+      await act(() => vi.advanceTimersByTimeAsync(refreshInterval));
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(2);
+
+      // 8분 후
+      await act(() => vi.advanceTimersByTimeAsync(refreshInterval));
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(3);
+    });
+
+    it('언마운트 시 interval이 정리된다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = 'existing-token';
+
+      mockTryRefreshToken.mockResolvedValue('new-token');
+
+      const refreshInterval = 4 * 60 * 1000;
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      const { unmount } = renderHook(() => useTokenRefresh(refreshInterval));
+
+      // 초기 호출
+      await act(() => vi.advanceTimersByTimeAsync(100));
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+
+      // 언마운트
+      unmount();
+
+      // 언마운트 후 interval이 실행되어도 호출되지 않아야 함
+      await act(() => vi.advanceTimersByTimeAsync(refreshInterval * 2));
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('중복 호출 방지', () => {
+    it('동시에 여러 refresh가 진행되지 않는다', async () => {
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = 'existing-token';
+
+      // 느린 응답 시뮬레이션
+      let resolveFirst: ((value: string) => void) | null = null;
+      mockTryRefreshToken.mockImplementation(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh(100)); // 짧은 interval
+
+      // 첫 번째 호출 시작
+      await act(() => vi.advanceTimersByTimeAsync(50));
+
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+
+      // interval이 지나도 첫 번째가 진행 중이면 새 호출 안 함
+      await act(() => vi.advanceTimersByTimeAsync(100));
+
+      // inFlightRef로 인해 중복 호출 방지
+      // 현재 구현에서는 interval 콜백이 실행되지만 inFlightRef.current가 true면 즉시 반환
+      expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
+
+      // 첫 번째 완료
+      if (resolveFirst) {
+        resolveFirst('new-token');
+      }
+    });
+  });
+
+  describe('마이그레이션 후 동작 (isInitialized)', () => {
+    // 마이그레이션 후 isHydrated → isInitialized로 변경됨
+    // 이 테스트는 마이그레이션 후에도 동일하게 동작해야 함
+    it('초기화 상태에 따라 동작이 제어된다', async () => {
+      // 현재: isHydrated 사용
+      // 마이그레이션 후: isInitialized 사용
+      mockStoreState.isHydrated = true;
+      mockStoreState.user = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+      mockStoreState.accessToken = 'token';
+
+      mockTryRefreshToken.mockResolvedValue('new-token');
+
+      const { useTokenRefresh } = await import('../useTokenRefresh');
+      renderHook(() => useTokenRefresh());
+
+      await act(() => vi.advanceTimersByTimeAsync(100));
+
+      expect(mockTryRefreshToken).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/useTokenRefresh.test.ts
+++ b/src/hooks/__tests__/useTokenRefresh.test.ts
@@ -208,7 +208,7 @@ describe('useTokenRefresh', () => {
       mockStoreState.accessToken = 'existing-token';
 
       // 느린 응답 시뮬레이션
-      let resolveFirst: ((value: string) => void) | null = null;
+      let resolveFirst!: (value: string | PromiseLike<string>) => void;
       mockTryRefreshToken.mockImplementation(
         () =>
           new Promise<string>((resolve) => {
@@ -232,9 +232,7 @@ describe('useTokenRefresh', () => {
       expect(mockTryRefreshToken).toHaveBeenCalledTimes(1);
 
       // 첫 번째 완료
-      if (resolveFirst) {
-        resolveFirst('new-token');
-      }
+      resolveFirst('new-token');
     });
   });
 

--- a/src/hooks/useAuthInitializer.ts
+++ b/src/hooks/useAuthInitializer.ts
@@ -24,6 +24,17 @@ export function useAuthInitializer() {
 
     const initialize = async () => {
       try {
+        // 레거시(localStorage persist) 데이터 정리
+        // - 마이그레이션 이전에 저장된 auth-storage가 남아있을 수 있음
+        // - 현재는 메모리 저장만 사용하므로 안전하게 제거
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.removeItem('auth-storage');
+          } catch {
+            // localStorage 접근 불가(브라우저 정책/사파리 프라이빗 등)인 경우 무시
+          }
+        }
+
         logger.info('[AuthInitializer] 앱 초기화 시작 - refreshToken으로 인증 복원 시도');
 
         // refreshToken으로 accessToken + user 정보 발급

--- a/src/hooks/useAuthInitializer.ts
+++ b/src/hooks/useAuthInitializer.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAuthStore } from '@/lib/store/authStore';
+import { tryRefreshToken } from '@/utils/api';
+import { logger } from '@/utils/logger';
+
+/**
+ * 앱 초기화 시 refreshToken으로 인증 상태 복원
+ * - 페이지 새로고침 시 자동 실행
+ * - refreshToken(httpOnly cookie)으로 accessToken 재발급
+ * - refresh API가 user 정보를 포함하므로 추가 API 호출 불필요
+ *   (단, refresh API에서 user 정보를 받지 못한 경우에만 추가 처리 필요)
+ */
+export function useAuthInitializer() {
+  const initAttempted = useRef(false);
+  const setInitialized = useAuthStore((state) => state.setInitialized);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
+
+  useEffect(() => {
+    // 이미 초기화되었거나 시도한 경우 스킵
+    if (isInitialized || initAttempted.current) return;
+    initAttempted.current = true;
+
+    const initialize = async () => {
+      try {
+        logger.info('[AuthInitializer] 앱 초기화 시작 - refreshToken으로 인증 복원 시도');
+
+        // refreshToken으로 accessToken + user 정보 발급
+        // tryRefreshToken 내부에서 setAuth를 호출하여 store에 저장함
+        const accessToken = await tryRefreshToken();
+
+        if (accessToken) {
+          logger.info('[AuthInitializer] 인증 복원 성공');
+        } else {
+          // accessToken이 null이면 refreshToken이 없거나 만료됨
+          // 로그인이 필요한 상태로 초기화 완료
+          logger.info('[AuthInitializer] refreshToken 없음/만료 - 로그인 필요');
+        }
+      } catch (error) {
+        // 네트워크 오류 등 일시적 장애
+        // 로그인 필요 상태로 초기화 완료 (강제 로그아웃하지 않음)
+        logger.warn('[AuthInitializer] 인증 복원 실패:', {
+          errorType: error instanceof Error ? error.constructor.name : 'Unknown',
+          errorMessage: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        // 성공/실패와 관계없이 초기화 완료 표시
+        setInitialized();
+      }
+    };
+
+    // 비동기 함수 실행
+    initialize().catch(() => {
+      // initialize 내부에서 try/catch로 처리하지만,
+      // eslint(no-void) 규칙을 피하고 예외 누수를 방지하기 위해 방어적으로 catch 처리
+    });
+  }, [isInitialized, setInitialized]);
+}

--- a/src/hooks/useTokenRefresh.ts
+++ b/src/hooks/useTokenRefresh.ts
@@ -9,75 +9,29 @@ import { logger } from '@/utils/logger';
  * 토큰 자동 갱신 훅
  * - Refresh interval: 4분 (기본값, accessToken 5분 만료 전에 갱신)
  * - Refresh token 만료 시간: 백엔드 .env의 JWT_REFRESH_EXPIRY 설정값 (기본값: 1h)
- * - Refresh token 만료 시 (401 에러) 자동 로그아웃 처리
- * - Rehydration 후 accessToken이 없으면 refresh 시도 (한 번만)
+ * - Refresh token 만료 시 (401 에러) 다음 사용자 액션에서 로그인 유도
+ * - 초기화(refreshToken으로 복원)는 useAuthInitializer에서 처리됨
  */
 export function useTokenRefresh(refreshInterval: number = 4 * 60 * 1000) {
   const accessToken = useAuthStore((state) => state.accessToken);
   const user = useAuthStore((state) => state.user);
-  const isHydrated = useAuthStore((state) => state.isHydrated);
+  const isInitialized = useAuthStore((state) => state.isInitialized);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const inFlightRef = useRef(false); // 중복 refresh 방지
   const mountedRef = useRef(false); // 언마운트 레이스 방지
-  const rehydrationAttemptedRef = useRef(false); // rehydration 후 refresh 시도 여부
 
   useEffect(() => {
     mountedRef.current = true;
 
-    // rehydration이 완료되지 않았으면 대기
-    if (!isHydrated) {
-      return () => {
-        mountedRef.current = false;
-      };
-    }
-
-    // rehydration 후 accessToken이 없으면 refresh 시도 (한 번만)
-    // 단, user 정보가 있는 경우에만 시도 (로그인했던 이력이 있는 경우)
-    // user 정보도 없으면 이미 로그인하지 않은 상태이므로 토큰 갱신 시도하지 않음
-    if (!accessToken && !user && !rehydrationAttemptedRef.current) {
-      // 로그인하지 않은 상태이므로 토큰 갱신 시도하지 않음
-      rehydrationAttemptedRef.current = true;
-      return () => {
-        mountedRef.current = false;
-      };
-    }
-
-    // user 정보는 있지만 accessToken이 없는 경우 (예: localStorage에서 user는 복원되었지만 accessToken은 만료된 경우)
-    if (!accessToken && user && !rehydrationAttemptedRef.current) {
-      rehydrationAttemptedRef.current = true;
-      const attemptRefresh = async () => {
-        if (inFlightRef.current) return;
-        inFlightRef.current = true;
-
-        try {
-          logger.info('[Token Refresh] Rehydration 후 토큰 갱신 시도 (user 정보는 있음)');
-          const newToken = await tryRefreshToken();
-          if (newToken) {
-            logger.info('[Token Refresh] Rehydration 후 토큰 갱신 성공');
-          } else {
-            // refresh token 만료/없음(401)
-            // 포커스 복귀/백그라운드 타이밍에 자동 로그아웃처럼 보이는 현상을 막기 위해
-            // 여기서 localStorage를 지우지 않고, 이후 사용자 액션(API 호출/가드)에서 로그인 유도
-            logger.warn('[Token Refresh] Rehydration 후 토큰 갱신 실패 - refresh token 만료/없음');
-          }
-        } catch (error: unknown) {
-          logger.warn('[Token Refresh] Rehydration 후 토큰 갱신 중 예외 발생', {
-            hasError: true,
-            errorType: error instanceof Error ? error.constructor.name : 'Unknown',
-          });
-          // 일시 장애는 자동 로그아웃(스토리지 삭제)하지 않음
-        } finally {
-          inFlightRef.current = false;
-        }
-      };
-      // eslint-disable-next-line no-void
-      void attemptRefresh();
+    // 초기화가 완료되지 않았으면 대기
+    if (!isInitialized) {
       return () => {
         mountedRef.current = false;
       };
     }
 
     // accessToken 또는 user가 없으면 주기적 refresh 중단
+    // (로그인하지 않은 상태이므로 갱신할 토큰이 없음)
     if (!accessToken || !user) {
       if (intervalRef.current) {
         clearInterval(intervalRef.current);
@@ -97,7 +51,7 @@ export function useTokenRefresh(refreshInterval: number = 4 * 60 * 1000) {
         if (!newToken) {
           // refresh token이 만료되었거나 없음 (401 에러)
           // 주기적 갱신 타이밍에 자동 로그아웃처럼 보이는 현상을 막기 위해
-          // 여기서 localStorage를 지우거나 강제 리다이렉트하지 않음
+          // 여기서 강제 리다이렉트하지 않음
           logger.warn('[Token Refresh] Refresh token 만료 - 다음 사용자 액션에서 로그인 유도');
         }
       } catch (error: unknown) {
@@ -105,21 +59,24 @@ export function useTokenRefresh(refreshInterval: number = 4 * 60 * 1000) {
           hasError: true,
           errorType: error instanceof Error ? error.constructor.name : 'Unknown',
         });
-        // 일시 장애는 자동 로그아웃(스토리지 삭제)하지 않음
+        // 일시 장애는 자동 로그아웃하지 않음
       } finally {
         // 언마운트 이후라도 플래그는 정리 (메모리/상태 누수 방지)
         inFlightRef.current = false;
       }
     };
 
-    // 마운트 시 즉시 한 번 실행
-    // eslint-disable-next-line no-void
-    void refreshToken();
+    // 마운트 시 즉시 한 번 실행 (accessToken 갱신)
+    refreshToken().catch(() => {
+      // refreshToken 내부에서 try/catch로 처리하지만,
+      // eslint(no-void) 규칙을 피하고 예외 누수를 방지하기 위해 방어적으로 catch 처리
+    });
 
     intervalRef.current = setInterval(() => {
       if (!mountedRef.current) return;
-      // eslint-disable-next-line no-void
-      void refreshToken();
+      refreshToken().catch(() => {
+        // 위와 동일한 이유로 catch 처리
+      });
     }, refreshInterval);
 
     return () => {
@@ -129,5 +86,5 @@ export function useTokenRefresh(refreshInterval: number = 4 * 60 * 1000) {
         intervalRef.current = null;
       }
     };
-  }, [accessToken, user, isHydrated, refreshInterval]);
+  }, [accessToken, user, isInitialized, refreshInterval]);
 }

--- a/src/lib/store/__tests__/authStore.test.ts
+++ b/src/lib/store/__tests__/authStore.test.ts
@@ -191,17 +191,15 @@ describe('authStore', () => {
     });
   });
 
-  describe('isHydrated/isInitialized 상태', () => {
-    it('setHydrated로 isHydrated를 true로 설정한다', async () => {
+  describe('isInitialized 상태', () => {
+    it('setInitialized로 isInitialized를 true로 설정한다', async () => {
       const { useAuthStore } = await import('../authStore');
 
-      // 현재 구현은 isHydrated 사용
-      // 마이그레이션 후에는 isInitialized로 변경될 예정
       act(() => {
-        useAuthStore.getState().setHydrated();
+        useAuthStore.getState().setInitialized();
       });
 
-      expect(useAuthStore.getState().isHydrated).toBe(true);
+      expect(useAuthStore.getState().isInitialized).toBe(true);
     });
   });
 

--- a/src/lib/store/__tests__/authStore.test.ts
+++ b/src/lib/store/__tests__/authStore.test.ts
@@ -1,0 +1,257 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { act } from '@testing-library/react';
+
+// localStorage mock
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn((index: number) => Object.keys(store)[index] || null),
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+// logger mock
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('authStore', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('초기 상태', () => {
+    it('초기 상태가 올바르게 설정된다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      const state = useAuthStore.getState();
+
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+      expect(state.isLoading).toBe(false);
+    });
+  });
+
+  describe('setAuth', () => {
+    it('user와 accessToken을 설정한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      const mockUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user' as const,
+        companyId: 'company-1',
+      };
+      const mockToken = 'mock-access-token';
+
+      act(() => {
+        useAuthStore.getState().setAuth({ user: mockUser, accessToken: mockToken });
+      });
+
+      const state = useAuthStore.getState();
+      expect(state.user).toEqual(mockUser);
+      expect(state.accessToken).toBe(mockToken);
+    });
+
+    it('null 값으로 설정할 수 있다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      // 먼저 값을 설정
+      act(() => {
+        useAuthStore.getState().setAuth({
+          user: {
+            id: 'user-1',
+            email: 'test@example.com',
+            name: 'Test User',
+            role: 'user' as const,
+            companyId: 'company-1',
+          },
+          accessToken: 'token',
+        });
+      });
+
+      // null로 초기화
+      act(() => {
+        useAuthStore.getState().setAuth({ user: null, accessToken: null });
+      });
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+    });
+  });
+
+  describe('setUser', () => {
+    it('user만 업데이트한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      const initialUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user' as const,
+        companyId: 'company-1',
+      };
+
+      act(() => {
+        useAuthStore.getState().setAuth({ user: initialUser, accessToken: 'token' });
+      });
+
+      const updatedUser = { ...initialUser, name: 'Updated User' };
+
+      act(() => {
+        useAuthStore.getState().setUser(updatedUser);
+      });
+
+      const state = useAuthStore.getState();
+      expect(state.user?.name).toBe('Updated User');
+      expect(state.accessToken).toBe('token'); // accessToken은 유지
+    });
+  });
+
+  describe('clearAuth', () => {
+    it('인증 정보를 초기화한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      // 먼저 값을 설정
+      act(() => {
+        useAuthStore.getState().setAuth({
+          user: {
+            id: 'user-1',
+            email: 'test@example.com',
+            name: 'Test User',
+            role: 'user' as const,
+            companyId: 'company-1',
+          },
+          accessToken: 'token',
+        });
+      });
+
+      // 초기화
+      act(() => {
+        useAuthStore.getState().clearAuth();
+      });
+
+      const state = useAuthStore.getState();
+      expect(state.user).toBeNull();
+      expect(state.accessToken).toBeNull();
+    });
+  });
+
+  describe('isLoading 상태', () => {
+    it('startLoading으로 isLoading을 true로 설정한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      act(() => {
+        useAuthStore.getState().startLoading();
+      });
+
+      expect(useAuthStore.getState().isLoading).toBe(true);
+    });
+
+    it('finishLoading으로 isLoading을 false로 설정한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      act(() => {
+        useAuthStore.getState().startLoading();
+      });
+
+      act(() => {
+        useAuthStore.getState().finishLoading();
+      });
+
+      expect(useAuthStore.getState().isLoading).toBe(false);
+    });
+  });
+
+  describe('isHydrated/isInitialized 상태', () => {
+    it('setHydrated로 isHydrated를 true로 설정한다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      // 현재 구현은 isHydrated 사용
+      // 마이그레이션 후에는 isInitialized로 변경될 예정
+      act(() => {
+        useAuthStore.getState().setHydrated();
+      });
+
+      expect(useAuthStore.getState().isHydrated).toBe(true);
+    });
+  });
+
+  describe('마이그레이션 후 동작 (localStorage 비사용)', () => {
+    it('마이그레이션 후 localStorage에 토큰이 저장되지 않아야 한다', async () => {
+      // 이 테스트는 마이그레이션 완료 후 통과해야 함
+      // 현재는 persist 사용 중이므로 skip 또는 조건부 실행
+      const { useAuthStore } = await import('../authStore');
+
+      act(() => {
+        useAuthStore.getState().setAuth({
+          user: {
+            id: 'user-1',
+            email: 'test@example.com',
+            name: 'Test User',
+            role: 'user' as const,
+            companyId: 'company-1',
+          },
+          accessToken: 'sensitive-token',
+        });
+      });
+
+      // 마이그레이션 후: localStorage에 auth-storage가 없어야 함
+      // 현재: persist 사용 중이므로 이 테스트는 실패할 수 있음
+      // 마이그레이션 완료 후 이 테스트가 통과해야 함
+
+      // TODO: 마이그레이션 후 아래 주석 해제
+      // expect(localStorageMock.getItem('auth-storage')).toBeNull();
+    });
+  });
+
+  describe('동시성 안전성', () => {
+    it('여러 번의 setAuth 호출이 순서대로 적용된다', async () => {
+      const { useAuthStore } = await import('../authStore');
+
+      const users = [
+        { id: '1', email: 'a@a.com', name: 'A', role: 'user' as const, companyId: 'c1' },
+        { id: '2', email: 'b@b.com', name: 'B', role: 'manager' as const, companyId: 'c2' },
+        { id: '3', email: 'c@c.com', name: 'C', role: 'admin' as const, companyId: 'c3' },
+      ];
+
+      users.forEach((user) => {
+        act(() => {
+          useAuthStore.getState().setAuth({ user, accessToken: `token-${user.id}` });
+        });
+      });
+
+      const finalState = useAuthStore.getState();
+      expect(finalState.user?.id).toBe('3');
+      expect(finalState.accessToken).toBe('token-3');
+    });
+  });
+});

--- a/src/lib/store/__tests__/authStore.test.ts
+++ b/src/lib/store/__tests__/authStore.test.ts
@@ -55,6 +55,7 @@ describe('authStore', () => {
       expect(state.user).toBeNull();
       expect(state.accessToken).toBeNull();
       expect(state.isLoading).toBe(false);
+      expect(state.isInitialized).toBe(false);
     });
   });
 
@@ -205,8 +206,6 @@ describe('authStore', () => {
 
   describe('마이그레이션 후 동작 (localStorage 비사용)', () => {
     it('마이그레이션 후 localStorage에 토큰이 저장되지 않아야 한다', async () => {
-      // 이 테스트는 마이그레이션 완료 후 통과해야 함
-      // 현재는 persist 사용 중이므로 skip 또는 조건부 실행
       const { useAuthStore } = await import('../authStore');
 
       act(() => {
@@ -222,12 +221,9 @@ describe('authStore', () => {
         });
       });
 
-      // 마이그레이션 후: localStorage에 auth-storage가 없어야 함
-      // 현재: persist 사용 중이므로 이 테스트는 실패할 수 있음
-      // 마이그레이션 완료 후 이 테스트가 통과해야 함
-
-      // TODO: 마이그레이션 후 아래 주석 해제
-      // expect(localStorageMock.getItem('auth-storage')).toBeNull();
+      // 마이그레이션 완료: authStore는 persist를 사용하지 않으므로 localStorage에 아무 것도 저장하지 않아야 함
+      expect(localStorageMock.getItem('auth-storage')).toBeNull();
+      expect(localStorageMock.setItem).not.toHaveBeenCalled();
     });
   });
 

--- a/src/lib/store/authStore.ts
+++ b/src/lib/store/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand';
-import { persist, createJSONStorage } from 'zustand/middleware';
 import type { UserRole } from '@/constants/roles';
 import { logger } from '@/utils/logger';
 
@@ -22,128 +21,57 @@ interface AuthState {
   user: User | null;
   accessToken: string | null;
   isLoading: boolean;
-  isHydrated: boolean;
+  isInitialized: boolean; // 앱 초기화 완료 여부 (구: isHydrated)
 
   setAuth: (payload: { user: User | null; accessToken: string | null }) => void;
   setUser: (user: User | null) => void;
   startLoading: () => void;
   finishLoading: () => void;
   clearAuth: () => void;
-  setHydrated: () => void;
+  setInitialized: () => void;
 }
 
 /**
  * 클라이언트 전역 인증 상태(Zustand)
- * - localStorage에 영구 저장 (페이지 새로고침 시에도 유지)
- * - accessToken 저장
+ * - 메모리에만 저장 (localStorage 사용 안 함)
+ * - 페이지 새로고침 시 refreshToken(httpOnly 쿠키)으로 복원
+ * - accessToken은 메모리에만 저장하여 XSS 피해 범위 축소
  * - refreshToken은 httpOnly 쿠키로 브라우저가 관리
  */
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      user: null,
-      accessToken: null,
-      isLoading: false,
-      isHydrated: false,
+export const useAuthStore = create<AuthState>()((set) => ({
+  user: null,
+  accessToken: null,
+  isLoading: false,
+  isInitialized: false,
 
-      setAuth: ({ user, accessToken }) => {
-        logger.info('[AuthStore] setAuth 호출:', {
-          hasUser: !!user,
-          hasAccessToken: !!accessToken,
-          userId: user?.id,
-          userEmail: user?.email,
-        });
-        set({ user, accessToken });
-        // Zustand persist는 동기적으로 localStorage에 저장하므로 즉시 확인 가능
-        if (typeof window !== 'undefined') {
-          const stored = localStorage.getItem('auth-storage');
-          try {
-            const parsedData = stored ? (JSON.parse(stored) as unknown) : null;
-            logger.info('[AuthStore] setAuth 후 localStorage 확인:', {
-              hasStored: !!stored,
-              storedData: parsedData,
-            });
-          } catch (parseError) {
-            logger.error('[AuthStore] localStorage 파싱 실패:', parseError);
-          }
-        }
-      },
-      setUser: (user) => set({ user }),
+  setAuth: ({ user, accessToken }) => {
+    logger.info('[AuthStore] setAuth 호출:', {
+      hasUser: !!user,
+      hasAccessToken: !!accessToken,
+      userId: user?.id,
+      userEmail: user?.email,
+    });
+    set({ user, accessToken });
+  },
 
-      startLoading: () => set({ isLoading: true }),
-      finishLoading: () => set({ isLoading: false }),
+  setUser: (user) => set({ user }),
 
-      clearAuth: () => {
-        set({ user: null, accessToken: null });
-        // localStorage에서 완전히 제거하여 다음 로드 시 null 상태가 복원되지 않도록 함
-        if (typeof window !== 'undefined') {
-          localStorage.removeItem('auth-storage');
-          logger.info('[AuthStore] clearAuth - localStorage 제거 완료');
-        }
-      },
-      setHydrated: () => set({ isHydrated: true }),
-    }),
-    {
-      name: 'auth-storage', // localStorage key
-      storage: createJSONStorage(() => localStorage),
-      // isLoading, isHydrated은 저장하지 않음 (페이지 로드 시마다 초기화)
-      partialize: (state) => ({
-        user: state.user,
-        accessToken: state.accessToken,
-      }),
-      onRehydrateStorage: () => {
-        // rehydration 시작 시 localStorage 확인
-        if (typeof window !== 'undefined') {
-          const stored = localStorage.getItem('auth-storage');
-          try {
-            const parsedData = stored ? (JSON.parse(stored) as unknown) : null;
-            logger.info('[AuthStore] Rehydration 시작 - localStorage 확인:', {
-              hasStored: !!stored,
-              storedData: parsedData,
-            });
-          } catch (parseError) {
-            logger.error('[AuthStore] Rehydration 시작 시 localStorage 파싱 실패:', parseError);
-          }
-        }
-        return (state, error) => {
-          if (error) {
-            // Rehydration 실패 시에도 isHydrated를 true로 설정하여 무한 대기 방지
-            const errorMessage = error instanceof Error ? error.message : 'Rehydration 실패';
-            logger.error('[AuthStore] Rehydration 실패:', errorMessage);
-            // 에러 발생 시에도 isHydrated 설정
-            if (state) {
-              state.setHydrated();
-            }
-            return;
-          }
-          // 성공 시: rehydration이 완료된 직후 isHydrated를 true로 설정
-          // 저장된 데이터 유무와 관계없이 localStorage를 건드리지 않고 상태만 표시
-          if (state) {
-            if (typeof window !== 'undefined') {
-              const stored = localStorage.getItem('auth-storage');
-              try {
-                const parsedData = stored ? (JSON.parse(stored) as unknown) : null;
-                logger.info('[AuthStore] Rehydration 후 localStorage 재확인:', {
-                  hasStored: !!stored,
-                  storedData: parsedData,
-                });
-              } catch (parseError) {
-                logger.error('[AuthStore] Rehydration 후 localStorage 파싱 실패:', parseError);
-              }
-            }
+  startLoading: () => set({ isLoading: true }),
+  finishLoading: () => set({ isLoading: false }),
 
-            state.setHydrated();
-            logger.info('[AuthStore] Rehydration 완료:', {
-              hasUser: !!state.user,
-              hasAccessToken: !!state.accessToken,
-              userId: state.user?.id,
-              userEmail: state.user?.email,
-            });
-          } else {
-            logger.warn('[AuthStore] Rehydration 완료되었지만 state가 null입니다.');
-          }
-        };
-      },
-    }
-  )
-);
+  clearAuth: () => {
+    logger.info('[AuthStore] clearAuth - 메모리에서 인증 정보 제거');
+    set({ user: null, accessToken: null });
+  },
+
+  setInitialized: () => {
+    logger.info('[AuthStore] setInitialized - 앱 초기화 완료');
+    set({ isInitialized: true });
+  },
+}));
+
+/**
+ * @deprecated isHydrated 대신 isInitialized 사용
+ * 하위 호환성을 위해 유지 (마이그레이션 완료 후 제거 예정)
+ */
+export const useIsHydrated = () => useAuthStore((state) => state.isInitialized);

--- a/src/lib/store/authStore.ts
+++ b/src/lib/store/authStore.ts
@@ -48,8 +48,6 @@ export const useAuthStore = create<AuthState>()((set) => ({
     logger.info('[AuthStore] setAuth 호출:', {
       hasUser: !!user,
       hasAccessToken: !!accessToken,
-      userId: user?.id,
-      userEmail: user?.email,
     });
     set({ user, accessToken });
   },

--- a/src/utils/__tests__/api.test.ts
+++ b/src/utils/__tests__/api.test.ts
@@ -1,0 +1,498 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+// fetch mock
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// logger mock
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// authStore mock
+const mockSetAuth = vi.fn();
+const mockClearAuth = vi.fn();
+
+interface MockUser {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  companyId: string;
+}
+
+interface MockStoreState {
+  user: MockUser | null;
+  accessToken: string | null;
+  setAuth: typeof mockSetAuth;
+  clearAuth: typeof mockClearAuth;
+}
+
+let mockStoreState: MockStoreState = {
+  user: null,
+  accessToken: null,
+  setAuth: mockSetAuth,
+  clearAuth: mockClearAuth,
+};
+
+vi.mock('@/lib/store/authStore', () => ({
+  useAuthStore: {
+    getState: () => mockStoreState,
+    setState: (newState: Partial<MockStoreState>) => {
+      mockStoreState = { ...mockStoreState, ...newState };
+    },
+  },
+}));
+
+// constants mock
+vi.mock('@/features/auth/utils/constants', () => ({
+  DEFAULT_API_URL: 'http://localhost:3000',
+  DEFAULT_TIMEOUT: 5000,
+  ENV_KEYS: {
+    API_URL: 'NEXT_PUBLIC_API_URL',
+    API_TIMEOUT: 'NEXT_PUBLIC_API_TIMEOUT',
+  },
+  AUTH_API_PATHS: {
+    REFRESH: '/api/v1/auth/refresh',
+    LOGIN: '/api/v1/auth/login',
+    LOGOUT: '/api/v1/auth/logout',
+  },
+}));
+
+describe('api.ts', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+
+    // Reset store state
+    mockStoreState = {
+      user: null,
+      accessToken: null,
+      setAuth: mockSetAuth,
+      clearAuth: mockClearAuth,
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('tryRefreshToken', () => {
+    it('성공 시 accessToken을 반환한다', async () => {
+      const mockAccessToken = 'new-access-token';
+      const mockUser = {
+        id: 'user-1',
+        companyId: 'company-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'USER',
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              accessToken: mockAccessToken,
+              user: mockUser,
+            },
+          }),
+      });
+
+      const { tryRefreshToken } = await import('../api');
+      const result = await tryRefreshToken();
+
+      expect(result).toBe(mockAccessToken);
+      expect(mockSetAuth).toHaveBeenCalledWith({
+        user: expect.objectContaining({
+          id: 'user-1',
+          email: 'test@example.com',
+        }),
+        accessToken: mockAccessToken,
+      });
+    });
+
+    it('401 응답 시 null을 반환한다 (refresh token 만료)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const { tryRefreshToken } = await import('../api');
+      const result = await tryRefreshToken();
+
+      expect(result).toBeNull();
+    });
+
+    it('403 응답 시 에러를 throw한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      });
+
+      const { tryRefreshToken } = await import('../api');
+
+      await expect(tryRefreshToken()).rejects.toThrow('토큰 갱신이 거부되었습니다');
+    });
+
+    it('네트워크 오류 시 예외를 전파한다', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { tryRefreshToken } = await import('../api');
+
+      await expect(tryRefreshToken()).rejects.toThrow('Network error');
+    });
+
+    it('타임아웃 시 에러를 throw한다', async () => {
+      // AbortError를 시뮬레이션
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+      mockFetch.mockRejectedValueOnce(abortError);
+
+      const { tryRefreshToken } = await import('../api');
+
+      await expect(tryRefreshToken()).rejects.toThrow('토큰 갱신 요청 시간이 초과되었습니다');
+    });
+
+    it('user 정보가 없는 응답에서도 accessToken을 반환한다', async () => {
+      const mockAccessToken = 'new-access-token';
+      const existingUser = {
+        id: 'user-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'user',
+        companyId: 'company-1',
+      };
+
+      // 기존 user 정보 설정
+      mockStoreState.user = existingUser;
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              accessToken: mockAccessToken,
+              // user 정보 없음
+            },
+          }),
+      });
+
+      const { tryRefreshToken } = await import('../api');
+      const result = await tryRefreshToken();
+
+      expect(result).toBe(mockAccessToken);
+      // 기존 user 정보가 유지되어야 함
+      expect(mockSetAuth).toHaveBeenCalledWith({
+        user: existingUser,
+        accessToken: mockAccessToken,
+      });
+    });
+  });
+
+  describe('handle401Error', () => {
+    it('토큰 갱신 성공 시 "refreshed"를 반환한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              accessToken: 'new-token',
+              user: {
+                id: 'user-1',
+                companyId: 'company-1',
+                email: 'test@example.com',
+                name: 'Test User',
+                role: 'USER',
+              },
+            },
+          }),
+      });
+
+      const { handle401Error } = await import('../api');
+      const result = await handle401Error();
+
+      expect(result).toBe('refreshed');
+    });
+
+    it('refresh token 만료 시 "expired"를 반환한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const { handle401Error } = await import('../api');
+      const result = await handle401Error();
+
+      expect(result).toBe('expired');
+    });
+
+    it('네트워크 오류 시 "failed"를 반환한다', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const { handle401Error } = await import('../api');
+      const result = await handle401Error();
+
+      expect(result).toBe('failed');
+    });
+  });
+
+  describe('fetchWithAuth', () => {
+    beforeEach(() => {
+      // accessToken 설정
+      mockStoreState.accessToken = 'existing-token';
+    });
+
+    it('Authorization 헤더에 Bearer 토큰을 포함한다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const { fetchWithAuth } = await import('../api');
+      await fetchWithAuth('/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer existing-token',
+          }),
+        })
+      );
+    });
+
+    it('credentials: include가 설정된다', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: 'test' }),
+      });
+
+      const { fetchWithAuth } = await import('../api');
+      await fetchWithAuth('/api/test');
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          credentials: 'include',
+        })
+      );
+    });
+
+    it('401 응답 시 토큰 갱신 후 재시도한다', async () => {
+      // 첫 번째 요청: 401
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      // 토큰 갱신 요청
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              accessToken: 'new-token',
+              user: {
+                id: 'user-1',
+                companyId: 'company-1',
+                email: 'test@example.com',
+                name: 'Test User',
+                role: 'USER',
+              },
+            },
+          }),
+      });
+
+      // 새 토큰 적용을 위해 store 업데이트 시뮬레이션
+      mockSetAuth.mockImplementationOnce(
+        ({ accessToken }: { accessToken: string; user: MockUser | null }) => {
+          mockStoreState.accessToken = accessToken;
+        }
+      );
+
+      // 재시도 요청: 성공
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: 'success' }),
+      });
+
+      const { fetchWithAuth } = await import('../api');
+      const response = await fetchWithAuth('/api/test');
+
+      expect(response.ok).toBe(true);
+      // 총 3번 호출: 원래 요청 + 토큰 갱신 + 재시도
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('accessToken이 없으면 먼저 갱신을 시도한다', async () => {
+      mockStoreState.accessToken = null;
+
+      // 토큰 갱신 요청
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            success: true,
+            data: {
+              accessToken: 'new-token',
+              user: {
+                id: 'user-1',
+                companyId: 'company-1',
+                email: 'test@example.com',
+                name: 'Test User',
+                role: 'USER',
+              },
+            },
+          }),
+      });
+
+      // 새 토큰 적용
+      mockSetAuth.mockImplementationOnce(
+        ({ accessToken }: { accessToken: string; user: MockUser | null }) => {
+          mockStoreState.accessToken = accessToken;
+        }
+      );
+
+      // 실제 요청
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ data: 'success' }),
+      });
+
+      const { fetchWithAuth } = await import('../api');
+      const response = await fetchWithAuth('/api/test');
+
+      expect(response.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('토큰이 없고 갱신도 실패하면 에러를 throw한다', async () => {
+      mockStoreState.accessToken = null;
+
+      // 토큰 갱신 실패 (401)
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const { fetchWithAuth } = await import('../api');
+
+      await expect(fetchWithAuth('/api/test')).rejects.toThrow(
+        '인증 토큰이 없습니다. 로그인이 필요합니다.'
+      );
+    });
+  });
+
+  describe('동시성 테스트', () => {
+    it('여러 401 응답이 동시에 발생해도 refresh는 정상 처리된다', async () => {
+      // 이 테스트는 현재 구현에서 동시성 보장이 필요한 부분을 검증
+      // 마이그레이션 후 전역 락이 적용되면 더 엄격한 테스트 필요
+
+      mockStoreState.accessToken = 'old-token';
+
+      const mockUser = {
+        id: 'user-1',
+        companyId: 'company-1',
+        email: 'test@example.com',
+        name: 'Test User',
+        role: 'USER',
+      };
+
+      // 여러 번의 handle401Error 호출
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              success: true,
+              data: { accessToken: 'token-1', user: mockUser },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              success: true,
+              data: { accessToken: 'token-2', user: mockUser },
+            }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              success: true,
+              data: { accessToken: 'token-3', user: mockUser },
+            }),
+        });
+
+      const { handle401Error } = await import('../api');
+
+      // 동시에 3개의 handle401Error 호출
+      const results = await Promise.all([handle401Error(), handle401Error(), handle401Error()]);
+
+      // 모든 호출이 성공해야 함
+      expect(results).toEqual(['refreshed', 'refreshed', 'refreshed']);
+    });
+
+    it('refresh 실패 시 무한 루프가 발생하지 않는다', async () => {
+      mockStoreState.accessToken = 'old-token';
+
+      // 계속 401 반환
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      });
+
+      const { handle401Error } = await import('../api');
+
+      const result = await handle401Error();
+
+      // expired로 처리되어야 함
+      expect(result).toBe('expired');
+      // refresh는 1번만 호출되어야 함
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('AuthExpiredError', () => {
+    it('올바르게 생성된다', async () => {
+      const { AuthExpiredError } = await import('../api');
+
+      const error = new AuthExpiredError('Test error', 401, null, { message: 'expired' });
+
+      expect(error.name).toBe('AuthExpiredError');
+      expect(error.message).toBe('Test error');
+      expect(error.status).toBe(401);
+      expect(error.responseData).toEqual({ message: 'expired' });
+    });
+  });
+});


### PR DESCRIPTION
## 변경사항

이번 머지는 인증 아키텍처의 핵심 전환을 포함한 릴리스입니다.  
기존 localStorage 기반 인증 상태 관리를 제거하고, refreshToken을 기준으로 앱 시작 시 인증을 초기화하는
메모리 기반 인증 흐름으로 전환했습니다.

해당 변경에 맞춰 단위 테스트 및 E2E 테스트를 전면 정비하고,
인증 플로우 전반의 안정성, 보안성, 접근성을 함께 강화했습니다.

## 작업 내용

- [x] accessToken / user 정보를 localStorage에서 메모리 상태로 마이그레이션
- [x] 앱 시작 시 refreshToken(httpOnly 쿠키) 기반 인증 초기화 훅 도입
- [x] 인증 초기화 완료 전 Providers 레벨 로딩 처리
- [x] AuthGuard / Dashboard / Chatbot 인증 판단 기준을 isInitialized로 통일
- [x] 토큰 자동 갱신 로직을 초기화 완료 이후로 제한
- [x] AuthGuard, useTokenRefresh, authStore 단위 테스트 추가
- [x] 인증 마이그레이션 흐름에 맞춰 테스트 시나리오 전면 수정
- [x] Playwright E2E 인증 플로우 안정화 및 플레이키 이슈 제거
- [x] E2E 로그인 자격증명 하드코딩 제거 및 환경변수 기반 실행
- [x] 인증 관련 로그에서 사용자 식별 정보(PII) 제거

## 테스트 방법

1. Vitest를 통한 auth 관련 단위 테스트 실행
2. Playwright로 로그인, 인증 유지, 리다이렉트 플로우 E2E 테스트
3. 인증 초기화 전/후 가드 및 대시보드 접근 수동 확인

## 관련 이슈
Closes #196


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **UI/UX 개선**
  * 대시보드 카드의 태블릿 환경 반응형 레이아웃 최적화
  * 관리 패널의 사이드바 스타일링 업데이트
  * 전체 레이아웃 간격 및 패딩 조정으로 더 나은 화면 공간 활용

* **로그인 기능 개선**
  * 로그인 폼의 다중 디바이스 호환성 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->