### PR TITLE
Fix: Prevent CLS by Aligning ProductCard Skeleton Responsive Layout

### DIFF
--- a/src/components/molecules/ProductCard/ProductCard.tsx
+++ b/src/components/molecules/ProductCard/ProductCard.tsx
@@ -65,7 +65,7 @@ const ProductCard = ({
 
   const rootClasses = clsx(
     'flex flex-col overflow-hidden',
-    'rounded-8 bg-white text-left rounded-default',
+    'rounded-default bg-white text-left',
     'shadow-card',
     'transition-[transform,box-shadow,border] duration-300 ease-out',
     'hover:animate-border-shimmer hover:-translate-y-2',

--- a/src/components/molecules/ProductCard/ProductCardSkeleton.tsx
+++ b/src/components/molecules/ProductCard/ProductCardSkeleton.tsx
@@ -11,7 +11,7 @@ interface ProductCardSkeletonProps {
 const ProductCardSkeleton = ({ variant = 'product', className }: ProductCardSkeletonProps) => {
   const rootClasses = clsx(
     'flex flex-col overflow-hidden',
-    'rounded-8 bg-white text-left rounded-default',
+    'rounded-default bg-white text-left',
     'shadow-card',
 
     // ProductCard와 동일한 반응형 aspect-ratio 사용

--- a/src/components/molecules/ProductCard/ProductCardSkeleton.tsx
+++ b/src/components/molecules/ProductCard/ProductCardSkeleton.tsx
@@ -11,41 +11,40 @@ interface ProductCardSkeletonProps {
 const ProductCardSkeleton = ({ variant = 'product', className }: ProductCardSkeletonProps) => {
   const rootClasses = clsx(
     'flex flex-col overflow-hidden',
-    'rounded-default bg-white text-left',
+    'rounded-8 bg-white text-left rounded-default',
     'shadow-card',
 
-    // Product / Order - 이미지 + 텍스트를 수용할 수 있도록 h-auto 사용
-    (variant === 'product' || variant === 'order') && 'w-155 h-auto tablet:w-156 desktop:w-367',
+    // ProductCard와 동일한 반응형 aspect-ratio 사용
+    (variant === 'product' || variant === 'order') &&
+      'w-full aspect-[155/241] tablet:aspect-[156/252] desktop:aspect-[367/439]',
 
     // Wishlist
-    variant === 'wishlist' && 'w-155 h-251 tablet:w-219 tablet:h-315 desktop:w-373 desktop:h-445',
+    variant === 'wishlist' &&
+      'w-full aspect-[155/251] tablet:aspect-[219/315] desktop:aspect-[373/445]',
 
     className
   );
 
   return (
     <div className={rootClasses}>
-      {/* Image */}
+      {/* 이미지 영역 - ProductCard와 동일하게 정사각형 */}
       <div
         className={clsx(
           'relative rounded-default bg-gray-50 flex items-center justify-center overflow-hidden',
-          (variant === 'product' || variant === 'order') &&
-            'w-155 h-155 tablet:w-156 tablet:h-156 desktop:w-367 desktop:h-280',
-          variant === 'wishlist' &&
-            'w-155 h-155 tablet:w-219 tablet:h-219 desktop:w-373 desktop:h-373'
+          'w-full aspect-square'
         )}
       >
         <div className="relative w-full h-full">
           <SkeletonUI className="absolute inset-0 w-full h-full" />
         </div>
 
-        {/* Heart 버튼 */}
+        {/* 하트 버튼 */}
         <div className="absolute bottom-10 right-10 w-17 h-17 desktop:bottom-20 desktop:right-20 desktop:w-25 desktop:h-25">
           <SkeletonUI className="w-full h-full rounded-full" />
         </div>
       </div>
 
-      {/* Text */}
+      {/* 텍스트 영역 */}
       <div className="flex flex-col flex-1 min-w-0 px-8 pt-8 pb-12 gap-2">
         {/* ProductTile Skeleton */}
         {variant === 'product' || variant === 'wishlist' ? (

--- a/src/components/molecules/ProductListRowSkeleton/ProductListRowSkeleton.tsx
+++ b/src/components/molecules/ProductListRowSkeleton/ProductListRowSkeleton.tsx
@@ -21,30 +21,36 @@ const ProductListRowSkeleton = ({ rows = 6, className }: ProductListRowSkeletonP
         key={`product-row-skeleton-${index}`}
         className={clsx(
           'flex flex-col overflow-hidden',
-          'rounded-8 bg-white text-left rounded-default',
+          'rounded-default bg-white text-left',
           'shadow-card',
-          'w-155 h-241 tablet:w-156 tablet:h-252 desktop:w-367 desktop:h-439'
+          // ProductCard와 동일한 반응형 aspect-ratio 사용
+          'w-full aspect-[155/241] tablet:aspect-[156/252] desktop:aspect-[367/439]'
         )}
       >
+        {/* 이미지 영역 - ProductCard와 동일하게 정사각형 */}
         <div
           className={clsx(
             'relative rounded-default bg-gray-50 flex items-center justify-center overflow-hidden',
-            'w-155 h-241 tablet:w-156 tablet:h-252 desktop:w-367 desktop:h-439'
+            'w-full aspect-square'
           )}
         >
           <div className="relative w-full h-full">
             <SkeletonUI className="absolute inset-0 w-full h-full" />
           </div>
+          {/* 하트 버튼 */}
           <div className="absolute bottom-10 right-10 w-17 h-17 desktop:bottom-20 desktop:right-20 desktop:w-25 desktop:h-25">
             <SkeletonUI className="w-full h-full rounded-full" />
           </div>
         </div>
+        {/* 텍스트 영역 */}
         <div className="flex flex-col flex-1 min-w-0 px-8 pt-8 pb-12 gap-2">
+          {/* 모바일 + 태블릿 */}
           <div className="flex flex-col gap-2 desktop:hidden">
             <SkeletonUI className="h-22 w-3/4" />
             <SkeletonUI className="h-22 w-1/2" />
             <SkeletonUI className="h-18 w-1/3" />
           </div>
+          {/* 데스크톱 */}
           <div className="hidden desktop:flex desktop:flex-col desktop:gap-2">
             <div className="flex flex-row items-center gap-8">
               <SkeletonUI className="h-24 w-3/5" />


### PR DESCRIPTION
## 변경사항

ProductCard Skeleton UI가 실제 ProductCard 반응형 레이아웃과 일치하지 않아
로딩 중 레이아웃 시프트(CLS)가 발생하던 문제를 수정했습니다.

Skeleton 컴포넌트의 고정 픽셀 기반 스타일을 제거하고,
실제 카드 구조와 동일한 반응형/비율 기반 레이아웃으로 정렬했습니다.

## 작업 내용

- [x] ProductCardSkeleton을 ProductCard와 동일한 반응형 레이아웃으로 수정
- [x] ProductListRowSkeleton을 ProductCard 구조에 맞게 정렬
- [x] 고정 픽셀 값(`w-155`, `h-241` 등)을 aspect-ratio 기반 스타일로 변경
- [x] 이미지 영역을 `aspect-square`로 통일하여 CLS 발생 방지
- [x] 모바일 / 태블릿 / 데스크톱 환경에서 Skeleton ↔ 실제 UI 전환 시 레이아웃 안정성 확보

## 테스트 방법

1. 상품 목록 페이지 진입
2. 네트워크 throttling 또는 강제 로딩 상태에서 Skeleton UI 확인
3. Skeleton → ProductCard 전환 시 레이아웃 시프트 발생 여부 확인
4. 모바일 / 태블릿 / 데스크톱 뷰포트에서 반응형 동작 확인

## 스크린샷 (UI 변경 시)

| Before | After |
| ------ | ----- |
| <img width="305" height="230" alt="Screenshot 2026-01-22 at 10 16 26 PM (2)" src="https://github.com/user-attachments/assets/0a002a0b-7349-4299-a44a-1cf193049a0e" /> | <img width="305" height="214" alt="Screenshot 2026-01-22 at 10 15 08 PM (2)" src="https://github.com/user-attachments/assets/331770bc-d313-4fb4-a6da-12182942628a" /> |

## 관련 이슈

Closes #204 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 제품 카드·목록의 이미지 영역을 화면 크기별 일관된 비율로 변경해 반응형 레이아웃 개선
  * 카드 모서리 스타일을 통일(rounded-default)하여 시각적 일관성 향상
* **새로운 기능**
  * 목록 스켈레톤에 하트(찜) 버튼 스켈레톤 오버레이 추가
  * 모바일/데스크톱에서 텍스트 영역이 각각 최적화된 레이아웃으로 표시되도록 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->